### PR TITLE
Update jvmArgs for API, adding -XX:+UseContainerSupport

### DIFF
--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -283,7 +283,7 @@ serviceapi:
   ## @param serviceapi.javaArgs define the configuration for the JVM.
   ## For custom java keystore add parameter: -Djavax.net.ssl.trustStore=/etc/secret-volume/custom-pki.jks
   ##
-  jvmArgs: "-Djava.security.egd=file:/dev/./urandom -XX:+UseG1GC -XX:MinRAMPercentage=60.0 -XX:InitiatingHeapOccupancyPercent=70 -XX:MaxRAMPercentage=90.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+  jvmArgs: "-Djava.security.egd=file:/dev/./urandom -XX:+UseContainerSupport -XX:+UseG1GC -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0 -XX:InitiatingHeapOccupancyPercent=70 -XX:G1ReservePercent=20 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
   ## @param serviceapi.amqp define the configuration for the AMQP
   ##
   amqp:


### PR DESCRIPTION
Update API jvmArgs, add -XX:+UseContainerSupport to allow JVM to size itself automatically based on the pod limit.
[Oracle Documentation link](https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-3B1CE181-CD30-4178-9602-230B800D4FAE)

`-XX:-UseContainerSupport`
The VM now provides automatic container detection support, which allows the VM to determine the amount of memory and number of processors that are available to a Java process running in docker containers. It uses this information to allocate system resources. This support is only available on Linux x64 platforms. If supported, the default for this flag is true, and container support is enabled by default. It can be disabled with `-XX:-UseContainerSupport`.