### PR TITLE
ArgoCD hook ordering for RBAC resources

### DIFF
--- a/docs/helm-pre-upgrade.md
+++ b/docs/helm-pre-upgrade.md
@@ -2,9 +2,27 @@
 
 Starting from version 24.1.3 we added the helm pre-upgrade hook to the chart.
 This hook is used to delete the old jobs to resolve a kubernetes issue with the job name.
-This hook doesn't work with the additional roles and role bindings.
 
-Before performing the helm upgrade you need to create the roles and role bindings manually:
+## ArgoCD Deployments
+
+If you are deploying the ReportPortal helm chart with ArgoCD, set `global.argocd.enabled=true` in your values:
+
+```yaml
+global:
+  argocd:
+    enabled: true
+```
+
+This ensures proper resource ordering through Helm hook weights:
+
+- Role (weight: 3)
+- ServiceAccount (weight: 4)
+- RoleBinding (weight: 5)
+- Pre-upgrade cleanup Job (weight: 10)
+
+## Standard Helm Deployments
+
+For standard Helm deployments without ArgoCD, the hook doesn't work with the additional roles and role bindings. Before performing the helm upgrade you need to create the roles and role bindings manually:
 
 ```yaml
 # role.yaml

--- a/docs/parameters-reference.md
+++ b/docs/parameters-reference.md
@@ -16,7 +16,7 @@ This document provides a comprehensive reference of all configurable parameters 
 | `global.serviceAccount.create` | Create service account | `true` |
 | `global.serviceAccount.name` | Service account name | `reportportal` |
 | `global.serviceAccount.annotations` | Service account annotations | `{}` |
-| `global.argocd.enabled` | Enable ArgoCD webhooks | `false` |
+| `global.argocd.enabled` | Enable ArgoCD webhooks for ServiceAccount, Role, RoleBinding, and pre-upgrade-cleanup job. Set to true when deploying with ArgoCD to ensure proper resource ordering | `false` |
 | `global.securityContext` | Default security context for all pods | `{}` |
 | `global.tolerations` | Global tolerations for all components | `[]` |
 | `global.pdb.create` | Enable/disable Pod Disruption Budget creation | `true` |

--- a/reportportal/templates/authorization/role.yaml
+++ b/reportportal/templates/authorization/role.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- if .Values.global.argocd.enabled }}
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "3"
     {{- end }}
 rules:

--- a/reportportal/templates/authorization/rolebinding.yaml
+++ b/reportportal/templates/authorization/rolebinding.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- if .Values.global.argocd.enabled }}
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-weight": "4"
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "5"
     {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/reportportal/templates/authorization/serviceaccount.yaml
+++ b/reportportal/templates/authorization/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
     namespace: {{ .Release.Namespace }}
     annotations:
       {{- if .Values.global.argocd.enabled }}
-      "helm.sh/hook": pre-upgrade
-      "helm.sh/hook-weight": "5"
+      "helm.sh/hook": pre-install,pre-upgrade
+      "helm.sh/hook-weight": "4"
       {{- end }}
       {{- if .Values.global.serviceAccount.annotations }}
       {{- range $key, $value := .Values.global.serviceAccount.annotations }}

--- a/reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
+++ b/reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
@@ -24,9 +24,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
-      {{- if .Values.global.serviceAccount.create }}
-      serviceAccountName: {{ .Values.global.serviceAccount.name }}
-      {{- end }}
+      serviceAccountName: {{ include "reportportal.serviceAccountName" . }}
       restartPolicy: OnFailure
       containers:
       - name: delete-job

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -27,6 +27,11 @@ global:
     annotations: {}
   ## @param global.argocd.enabled Enable ArgoCD webhooks for ServiceAccount, Role, RoleBinding, and pre-upgrade cleanup
   ## Set to true when deploying with ArgoCD to ensure proper resource ordering
+  ## This adds helm.sh/hook annotations with weights to control deployment sequence:
+  ##   - Role: weight 3
+  ##   - ServiceAccount: weight 4
+  ##   - RoleBinding: weight 5
+  ##   - Pre-upgrade cleanup: weight 10
   ##
   argocd:
     enabled: false


### PR DESCRIPTION
## Context  

This PR fixes ArgoCD deployment failures by correcting Helm hook ordering for RBAC resources when `global.argocd.enabled=true`.

When deploying the ReportPortal Helm chart with ArgoCD, the `pre-upgrade-cleanup` job requires a ServiceAccount with appropriate RBAC permissions. Without proper hook ordering, ArgoCD may attempt to create the cleanup job before the `ServiceAccount`, `Role`, or `RoleBinding` exists, causing deployment failures.

### Issues with Previous Implementation

  1. **Missing `pre-install` phase**: Resources only had `pre-upgrade` hooks, causing failures on fresh/first-time ArgoCD installations. 
  - For example, since the service account only has `pre-upgrade` hook it means that it is going to be installed only when Argo deploys the report portal helm chart for the second time, [so an actual upgrade and not an install](https://helm.sh/docs/topics/charts_hooks/#the-available-hooks).
  
  2. **Incorrect weight ordering**: RoleBinding (weight: 4) was created before ServiceAccount (weight: 5), but RoleBinding references the ServiceAccount so the sa should be created first.
  
  3. **Inconsistent serviceAccountName**: Pre-upgrade cleanup job used an inline conditional instead of the helper template. This creates the issue [referenced here](https://github.com/reportportal/kubernetes/pull/523/changes#r2721564664)

### Proposal to consider:

This PR is adding Helm hook annotations with explicit weights to control resource creation order when `global.argocd.enabled:true`

| Resource | Hook Phase | Weight | File |
  |----------|------------|--------|------|
  | Role | pre-install,pre-upgrade | 3 | `templates/authorization/role.yaml` |
  | ServiceAccount | pre-install,pre-upgrade | 4 | `templates/authorization/serviceaccount.yaml` |
  | RoleBinding | pre-install,pre-upgrade | 5 | `templates/authorization/rolebinding.yaml` |
  | Pre-upgrade cleanup Job | pre-upgrade | 10 | `templates/hooks/upgrade/pre-upgrade-cleanup.yaml` |

- Then the dependency order would be: 
Role (3) → ServiceAccount (4) → RoleBinding (5) → Cleanup Job (10)
 
## Rationale

  - **RoleBinding** references both Role and ServiceAccount, so it must be created after both
  - **Cleanup Job** uses the ServiceAccount and needs RBAC permissions, so it runs last
  - **`pre-install,pre-upgrade`** ensures resources exist for both fresh installs and upgrades
  - **Weight gaps** (3,4,5,10) allow future hooks to be inserted if needed

---

## Testing and Validation

<details><summary>Chart Linting</summary>
<p>

<img width="963" height="867" alt="image" src="https://github.com/user-attachments/assets/e3ee3b22-0c25-4d62-8cf8-e488a70a48c4" />


</p>
</details>

<details><summary>Template Validation (ArgoCD Enabled)</summary>
<p>

```
helm template reportportal-test ./reportportal --set global.argocd.enabled=false
level=INFO msg="warning: destination for rabbitmq.ingress.tls is a table. Ignoring non-table value (false)"
level=INFO msg="warning: destination for minio.ingress.tls is a table. Ignoring non-table value (false)"
---
# Source: reportportal/charts/minio/templates/networkpolicy.yaml
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: minio
      app.kubernetes.io/component: minio
      app.kubernetes.io/part-of: minio
  policyTypes:
    - Ingress
    - Egress
  egress:
    - {}
  ingress:
    # Allow inbound connections
    - ports:
        - port: 9000
---
# Source: reportportal/charts/postgresql/templates/primary/networkpolicy.yaml
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
    app.kubernetes.io/component: primary
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: postgresql
      app.kubernetes.io/component: primary
  policyTypes:
    - Ingress
    - Egress
  egress:
    - {}
  ingress:
    - ports:
        - port: 5432
---
# Source: reportportal/charts/rabbitmq/templates/networkpolicy.yaml
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: rabbitmq
  policyTypes:
    - Ingress
    - Egress
  egress:
    - {}
  ingress:
    # Allow inbound connections to RabbitMQ
    - ports:
        - port: 4369
        - port: 5672
        - port: 5671
        - port: 25672
        - port: 15672
---
# Source: reportportal/charts/minio/templates/pdb.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: minio
      app.kubernetes.io/component: minio
      app.kubernetes.io/part-of: minio
---
# Source: reportportal/charts/opensearch/templates/poddisruptionbudget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: "opensearch-cluster-master-pdb"
  labels:
    helm.sh/chart: opensearch-2.36.0
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "2.19.4"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: opensearch-cluster-master
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: opensearch
      app.kubernetes.io/instance: reportportal-test
---
# Source: reportportal/charts/postgresql/templates/primary/pdb.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
    app.kubernetes.io/component: primary
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: postgresql
      app.kubernetes.io/component: primary
---
# Source: reportportal/charts/rabbitmq/templates/pdb.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: rabbitmq
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-index-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-index
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-ui-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-ui
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-api-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-api
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-uat-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-uat
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-jobs-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-jobs
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-analyzer-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-analyzer
---
# Source: reportportal/charts/minio/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/part-of: minio
automountServiceAccountToken: false
secrets:
  - name: reportportal-test-minio
---
# Source: reportportal/charts/postgresql/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
automountServiceAccountToken: false
---
# Source: reportportal/charts/rabbitmq/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
automountServiceAccountToken: false
secrets:
  - name: reportportal-test-rabbitmq
---
# Source: reportportal/templates/authorization/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
    name: reportportal
    namespace: eep-reportportal
    annotations:
---
# Source: reportportal/charts/minio/templates/secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
type: Opaque
data:
  root-user: "cnB1c2Vy"
  root-password: "xxxxxxx=="
---
# Source: reportportal/charts/postgresql/templates/secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
type: Opaque
data:
  postgres-password: "xxxxxx=="
  # We don't auto-generate LDAP password when it's not provided as we do for other passwords
---
# Source: reportportal/charts/rabbitmq/templates/config-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: reportportal-test-rabbitmq-config
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
type: Opaque
data:
  rabbitmq.conf: |-
    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCmRlZmF1bHRfdXNlciA9IHJhYmJpdG1xCiMjIENsdXN0ZXJpbmcKIyMKY2x1c3Rlcl9uYW1lID0gcmVwb3J0cG9ydGFsLXRlc3QtcmFiYml0bXEKY2x1c3Rlcl9mb3JtYXRpb24ucGVlcl9kaXNjb3ZlcnlfYmFja2VuZCAgPSByYWJiaXRfcGVlcl9kaXNjb3ZlcnlfazhzCmNsdXN0ZXJfZm9ybWF0aW9uLms4cy5ob3N0ID0ga3ViZXJuZXRlcy5kZWZhdWx0CmNsdXN0ZXJfZm9ybWF0aW9uLms4cy5hZGRyZXNzX3R5cGUgPSBob3N0bmFtZQpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuc2VydmljZV9uYW1lID0gcmVwb3J0cG9ydGFsLXRlc3QtcmFiYml0bXEtaGVhZGxlc3MKY2x1c3Rlcl9mb3JtYXRpb24uazhzLmhvc3RuYW1lX3N1ZmZpeCA9IC5yZXBvcnRwb3J0YWwtdGVzdC1yYWJiaXRtcS1oZWFkbGVzcy5lZXAtcmVwb3J0cG9ydGFsLnN2Yy5jbHVzdGVyLmxvY2FsCmNsdXN0ZXJfZm9ybWF0aW9uLm5vZGVfY2xlYW51cC5pbnRlcnZhbCA9IDEwCmNsdXN0ZXJfZm9ybWF0aW9uLm5vZGVfY2xlYW51cC5vbmx5X2xvZ193YXJuaW5nID0gdHJ1ZQpjbHVzdGVyX3BhcnRpdGlvbl9oYW5kbGluZyA9IGF1dG9oZWFsCgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgbG9vcGJhY2sgdXNlcgpsb29wYmFja191c2Vycy5yYWJiaXRtcSA9IGZhbHNlCm1heF9tZXNzYWdlX3NpemUgPSAxMzQyMTc3MjgKIyMgUHJvbWV0aGV1cyBtZXRyaWNzCiMjCnByb21ldGhldXMudGNwLnBvcnQgPSA5NDE5CiMjIFRDUCBMaXN0ZW4gT3B0aW9ucwojIwp0Y3BfbGlzdGVuX29wdGlvbnMuYmFja2xvZyA9IDEyOAp0Y3BfbGlzdGVuX29wdGlvbnMubm9kZWxheSA9IHRydWUKdGNwX2xpc3Rlbl9vcHRpb25zLmxpbmdlci5vbiAgICAgID0gdHJ1ZQp0Y3BfbGlzdGVuX29wdGlvbnMubGluZ2VyLnRpbWVvdXQgPSAwCnRjcF9saXN0ZW5fb3B0aW9ucy5rZWVwYWxpdmUgPSBmYWxzZQ==
---
# Source: reportportal/charts/rabbitmq/templates/secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
type: Opaque
data:
  rabbitmq-password: "xxxx=="
  rabbitmq-erlang-cookie: "OEhuUjc5S1dzdjkyR0hZbmpKZm5vYTBHRTMzTTN2M0o="
---
# Source: reportportal/templates/service-authorization/uat-init-password.yaml
apiVersion: v1
kind: Secret
metadata:
  name: reportportal-uat-init-password
  namespace: eep-reportportal
  labels:

    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
data:
  password: ""
---
# Source: reportportal/charts/opensearch/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: opensearch-cluster-master-config
  labels:
    helm.sh/chart: opensearch-2.36.0
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "2.19.4"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: opensearch-cluster-master
data:
  opensearch.yml: |
    cluster.name: opensearch-cluster

    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
    network.host: 0.0.0.0

    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
    # Implicitly done if ".singleNode" is set to "true".
    # discovery.type: single-node

    # Start OpenSearch Security Demo Configuration
    # WARNING: revise all the lines below before you go into production
    # plugins:
    #   security:
    #     ssl:
    #       transport:
    #         pemcert_filepath: esnode.pem
    #         pemkey_filepath: esnode-key.pem
    #         pemtrustedcas_filepath: root-ca.pem
    #         enforce_hostname_verification: false
    #       http:
    #         enabled: true
    #         pemcert_filepath: esnode.pem
    #         pemkey_filepath: esnode-key.pem
    #         pemtrustedcas_filepath: root-ca.pem
    #     allow_unsafe_democertificates: true
    #     allow_default_init_securityindex: true
    #     authcz:
    #       admin_dn:
    #         - CN=kirk,OU=client,O=client,L=test,C=de
    #     audit.type: internal_opensearch
    #     enable_snapshot_restore_privilege: true
    #     check_snapshot_restore_write_privileges: true
    #     restapi:
    #       roles_enabled: ["all_access", "security_rest_api_access"]
    #     system_indices:
    #       enabled: true
    #       indices:
    #         [
    #           ".opendistro-alerting-config",
    #           ".opendistro-alerting-alert*",
    #           ".opendistro-anomaly-results*",
    #           ".opendistro-anomaly-detector*",
    #           ".opendistro-anomaly-checkpoints",
    #           ".opendistro-anomaly-detection-state",
    #           ".opendistro-reports-*",
    #           ".opendistro-notifications-*",
    #           ".opendistro-notebooks",
    #           ".opendistro-asynchronous-search-response*",
    #         ]
    ######## End OpenSearch Security Demo Configuration ########
---
# Source: reportportal/charts/minio/templates/pvc.yaml
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
  annotations:
    helm.sh/resource-policy: keep
spec:
  accessModes:
    - "ReadWriteOnce"
  resources:
    requests:
      storage: "8Gi"
---
# Source: reportportal/charts/rabbitmq/templates/role.yaml
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: reportportal-test-rabbitmq-endpoint-reader
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
rules:
  - apiGroups: [""]
    resources: ["endpoints"]
    verbs: ["get"]
  - apiGroups: [""]
    resources: ["events"]
    verbs: ["create"]
---
# Source: reportportal/templates/authorization/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: reportportal-test-service-manager
  namespace: eep-reportportal
  annotations:
rules:
  # Allow the service account to get and list pods, services, and jobs
  - apiGroups: ["", "batch"]
    resources: ["pods","services", "jobs"]
    verbs: ["get", "list", "watch"]
  # Allow the service account to delete jobs
  - apiGroups: ["batch"]
    resources: ["jobs"]
    verbs: ["delete"]
---
# Source: reportportal/charts/rabbitmq/templates/rolebinding.yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: reportportal-test-rabbitmq-endpoint-reader
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
subjects:
  - kind: ServiceAccount
    name: reportportal-test-rabbitmq
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: reportportal-test-rabbitmq-endpoint-reader
---
# Source: reportportal/templates/authorization/rolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: reportportal-test-user-binding
  namespace: eep-reportportal
  annotations:
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: reportportal-test-service-manager
subjects:
  - kind: ServiceAccount
    name: reportportal
    namespace: eep-reportportal
---
# Source: reportportal/charts/minio/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
spec:
  type: ClusterIP
  ports:
    - name: tcp-api
      port: 9000
      targetPort: api
      nodePort: null
  selector:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/name: minio
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
---
# Source: reportportal/charts/opensearch/templates/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: opensearch-cluster-master
  labels:
    helm.sh/chart: opensearch-2.36.0
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "2.19.4"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: opensearch-cluster-master
  annotations:
    {}
spec:
  type: ClusterIP
  selector:
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
  ports:
  - name: http
    protocol: TCP
    port: 9200
  - name: transport
    protocol: TCP
    port: 9300
  - name: metrics
    protocol: TCP
    port: 9600
---
# Source: reportportal/charts/opensearch/templates/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: opensearch-cluster-master-headless
  labels:
    helm.sh/chart: opensearch-2.36.0
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "2.19.4"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: opensearch-cluster-master
  annotations:
    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
spec:
  clusterIP: None # This is needed for statefulset hostnames like opensearch-0 to resolve
  # Create endpoints also if the related pod isn't ready
  publishNotReadyAddresses: true
  selector:
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
  ports:
  - name: http
    port: 9200
  - name: transport
    port: 9300
  - name: metrics
    port: 9600
---
# Source: reportportal/charts/postgresql/templates/primary/svc-headless.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-postgresql-hl
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
    app.kubernetes.io/component: primary
  annotations:
spec:
  type: ClusterIP
  clusterIP: None
  # We want all pods in the StatefulSet to have their addresses published for
  # the sake of the other Postgresql pods even before they're ready, since they
  # have to be able to talk to each other in order to become ready.
  publishNotReadyAddresses: true
  ports:
    - name: tcp-postgresql
      port: 5432
      targetPort: tcp-postgresql
  selector:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/component: primary
---
# Source: reportportal/charts/postgresql/templates/primary/svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
    app.kubernetes.io/component: primary
spec:
  type: ClusterIP
  sessionAffinity: None
  ports:
    - name: tcp-postgresql
      port: 5432
      targetPort: tcp-postgresql
      nodePort: null
  selector:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/component: primary
---
# Source: reportportal/charts/rabbitmq/templates/svc-headless.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-rabbitmq-headless
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
spec:
  clusterIP: None
  ports:
    - name: epmd
      port: 4369
      targetPort: epmd
    - name: amqp
      port: 5672
      targetPort: amqp
    - name: dist
      port: 25672
      targetPort: dist
    - name: http-stats
      port: 15672
      targetPort: stats
  selector:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/name: rabbitmq
  publishNotReadyAddresses: true
  trafficDistribution: PreferClose
---
# Source: reportportal/charts/rabbitmq/templates/svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
spec:
  type: ClusterIP
  sessionAffinity: None
  ports:
    - name: amqp
      port: 5672
      targetPort: amqp
      nodePort: null
    - name: epmd
      port: 4369
      targetPort: epmd
      nodePort: null
    - name: dist
      port: 25672
      targetPort: dist
      nodePort: null
    - name: http-stats
      port: 15672
      targetPort: stats
      nodePort: null
  selector:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/name: rabbitmq
---
# Source: reportportal/templates/service-api/api-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-api
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    service: api
    infoEndpoint: "/api/info"
    healthEndpoint: "/api/health"
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 8585
    protocol: TCP
    targetPort: 8585
  selector:
    component: reportportal-test-api
---
# Source: reportportal/templates/service-authorization/uat-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-uat
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    service: uat
    infoEndpoint: "/uat/info"
    healthEndpoint: "/uat/health"
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 9999
    protocol: TCP
    targetPort: 9999
  selector:
    component: reportportal-test-uat
---
# Source: reportportal/templates/service-auto-analyzer/analyzer-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-analyzer
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 8080
    protocol: TCP
    targetPort: analyzercore
  selector:
    component: reportportal-test-analyzer
---
# Source: reportportal/templates/service-index/index-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-index
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    service: index
    infoEndpoint: "/info"
    healthEndpoint: "/health"
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 8080
    protocol: TCP
    targetPort: 8080
  selector:
    component: reportportal-test-index
---
# Source: reportportal/templates/service-jobs/jobs-services.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-jobs
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    service: jobs
    infoEndpoint: "/jobs/info"
    healthEndpoint: "/jobs/health"
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 8686
    protocol: TCP
    targetPort: 8686
  selector:
    component: reportportal-test-jobs
---
# Source: reportportal/templates/service-ui/ui-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-ui
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    service: ui
    infoEndpoint: "/ui/info"
    healthEndpoint: "/ui/health"
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 8080
    protocol: TCP
    targetPort: 8080
  selector:
    component: reportportal-test-ui
---
# Source: reportportal/charts/minio/templates/application.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
spec:
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: minio
      app.kubernetes.io/component: minio
      app.kubernetes.io/part-of: minio
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: reportportal-test
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: minio
        app.kubernetes.io/version: 2025.7.23
        helm.sh/chart: minio-17.0.16
        app.kubernetes.io/component: minio
        app.kubernetes.io/part-of: minio
      annotations:
        checksum/credentials-secret: 5f596bf1fd096880282979a69bf3aac6a9317fc784b1cfd07648236561312a76
    spec:

      serviceAccountName: reportportal-test-minio
      affinity:
        podAffinity:

        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app.kubernetes.io/instance: reportportal-test
                    app.kubernetes.io/name: minio
                    app.kubernetes.io/component: minio
                topologyKey: kubernetes.io/hostname
              weight: 1
        nodeAffinity:

      automountServiceAccountToken: false
      securityContext:
        fsGroup: 1001
        fsGroupChangePolicy: OnRootMismatch
        supplementalGroups: []
        sysctls: []
      initContainers:
      containers:
        - name: minio
          image: docker.io/bitnamilegacy/minio:2025.7.23-debian-12-r0
          imagePullPolicy: "IfNotPresent"
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsGroup: 1001
            runAsNonRoot: true
            runAsUser: 1001
            seLinuxOptions: {}
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: BITNAMI_DEBUG
              value: "false"
            - name: MINIO_DISTRIBUTED_MODE_ENABLED
              value: "no"
            - name: MINIO_SCHEME
              value: "http"
            - name: MINIO_FORCE_NEW_KEYS
              value: "no"
            - name: MINIO_ROOT_USER_FILE
              value: /opt/bitnami/minio/secrets/root-user
            - name: MINIO_ROOT_PASSWORD_FILE
              value: /opt/bitnami/minio/secrets/root-password
            - name: MINIO_SKIP_CLIENT
              value: "yes"
            - name: MINIO_API_PORT_NUMBER
              value: "9000"
            - name: MINIO_BROWSER
              value: "off"
            - name: MINIO_PROMETHEUS_AUTH_TYPE
              value: "public"
            - name: MINIO_DATA_DIR
              value: "/bitnami/minio/data"
          ports:
            - name: api
              containerPort: 9000
          livenessProbe:
            httpGet:
              path: /minio/health/live
              port: api
              scheme: "HTTP"
            initialDelaySeconds: 5
            periodSeconds: 5
            timeoutSeconds: 5
            successThreshold: 1
            failureThreshold: 5
          readinessProbe:
            tcpSocket:
              port: api
            initialDelaySeconds: 5
            periodSeconds: 5
            timeoutSeconds: 1
            successThreshold: 1
            failureThreshold: 5
          resources:
            limits:
              cpu: 375m
              ephemeral-storage: 2Gi
              memory: 384Mi
            requests:
              cpu: 250m
              ephemeral-storage: 50Mi
              memory: 256Mi
          volumeMounts:
            - name: empty-dir
              mountPath: /tmp
              subPath: tmp-dir
            - name: empty-dir
              mountPath: /opt/bitnami/minio/tmp
              subPath: app-tmp-dir
            - name: empty-dir
              mountPath: /.mc
              subPath: app-mc-dir
            - name: minio-credentials
              mountPath: /opt/bitnami/minio/secrets/
            - name: data
              mountPath: /bitnami/minio/data
      volumes:
        - name: empty-dir
          emptyDir: {}
        - name: minio-credentials
          secret:
            secretName: reportportal-test-minio
        - name: data
          persistentVolumeClaim:
            claimName: reportportal-test-minio
---
# Source: reportportal/templates/service-api/api-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-api
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-api
  template:
    metadata:
      labels:
        component: reportportal-test-api
      annotations:
    spec:
      initContainers:
        - name: migrations-waiting-init
          image: "reportportal/k8s-wait-for:latest"
          imagePullPolicy: IfNotPresent
          args:
            - "job-wr"
            - reportportal-test-migrations
          resources:
            requests:
              cpu: 50m
              memory: 100Mi
            limits:
              cpu: 50m
              memory: 100Mi
      containers:
        - name: "api"
          image: "reportportal/service-api:5.15.0"
          imagePullPolicy: "Always"
          ports:
            - containerPort: 8585
              protocol: TCP
          resources:
            limits:
              cpu: 1000m
              memory: 2Gi
            requests:
              cpu: 500m
              memory: 1Gi
          env:
            - name: SERVER_SERVLET_CONTEXT_PATH
              value: "/api"
            - name: COM_TA_REPORTPORTAL_JOB_LOAD_PLUGINS_CRON
              value: "PT10S"
            - name: RP_JOBS_BASEURL
              value: http://reportportal-test-jobs.eep-reportportal.svc.cluster.local:8686/jobs
            - name: COM_TA_REPORTPORTAL_JOB_INTERRUPT_BROKEN_LAUNCHES_CRON
              value: "PT1H"
            - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_BATCH-SIZE
              value: "100"
            - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_PREFETCH-COUNT
              value: "1"
            - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_CONSUMERS-COUNT
              value: "1"
            - name: RP_ENVIRONMENT_VARIABLE_ALLOW_DELETE_ACCOUNT
              value: "true"
            - name: LOGGING_LEVEL_ORG_HIBERNATE_SQL
              value: "info"
            - name: RP_REQUESTLOGGING
              value: "false"
            - name: JAVA_OPTS
              value: "-Djava.security.egd=file:/dev/./urandom -XX:+UseG1GC -XX:MinRAMPercentage=60.0 -XX:InitiatingHeapOccupancyPercent=70 -XX:MaxRAMPercentage=90.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
          # AMQP settings
            - name: REPORTING_QUEUES_COUNT
              value: "10"
            - name: REPORTING_PARKINGLOT_TTL_DAYS
              value: "7"
            - name: REPORTING_CONSUMER_PREFETCHCOUNT
              value: "10"
            - name: RP_AMQP_ANALYZER-VHOST
              value: "analyzer"
            - name: RP_AMQP_PASS
              value: "rabbitmqpassword"
            - name: RP_AMQP_API_ADDRESS
              value: http://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:15672/api
            - name: RP_AMQP_ADDRESSES
              value: amqp://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:5672
          # Database settings
            - name: RP_DB_HOST
              value: reportportal-test-postgresql.eep-reportportal.svc.cluster.local
            - name: RP_DB_PORT
              value: "5432"
            - name: RP_DB_NAME
              value: "reportportal"
            - name: RP_DB_USER
              value: "postgres"
            - name: RP_DB_PASS
              value: "rppassword"
        # Storage settings
            - name: DATASTORE_TYPE
              value: "minio"
        # Minio/S3 settings
            - name: DATASTORE_ENDPOINT
              value: "http://reportportal-test-minio.eep-reportportal.svc.cluster.local:9000"
            - name: DATASTORE_ACCESSKEY
              value: "rpuser"
            - name: DATASTORE_SECRETKEY
              value: "miniopassword"
            - name: DATASTORE_BUCKETPREFIX
              value: "prj-"
            - name: DATASTORE_BUCKETPOSTFIX
              value: ""
            - name: RP_INTEGRATION_SALT_PATH
              value: "keystore"
            - name: DATASTORE_DEFAULTBUCKETNAME
              value: "rp-bucket"
            - name: MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED
              value: "false"
          readinessProbe:
            httpGet:
              path: "/api/health"
              port: 8585
            initialDelaySeconds: 40
            periodSeconds: 20
            timeoutSeconds: 5
            failureThreshold: 20
          livenessProbe:
            tcpSocket:
              port: 8585
            initialDelaySeconds: 40
            periodSeconds: 20
            timeoutSeconds: 5
            failureThreshold: 10
          volumeMounts:
      securityContext:
        {}
      serviceAccountName: reportportal
      volumes:
---
# Source: reportportal/templates/service-authorization/uat-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-uat
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-uat
  template:
    metadata:
      labels:
        component: reportportal-test-uat
      annotations:
    spec:
      initContainers:
        - name: migrations-waiting-init
          image: "reportportal/k8s-wait-for:latest"
          imagePullPolicy: IfNotPresent
          args:
            - "job-wr"
            - reportportal-test-migrations
          resources:
            requests:
              cpu: 50m
              memory: 100Mi
            limits:
              cpu: 50m
              memory: 100Mi
      containers:
        - name: "uat"
          image: "reportportal/service-authorization:5.15.0"
          imagePullPolicy: "Always"
          ports:
            - containerPort: 9999
              protocol: TCP
          resources:
            requests:
              cpu: 100m
              memory: 512Mi
            limits:
              cpu: 500m
              memory: 1Gi
          env:
            - name: SERVER_SERVLET_CONTEXT_PATH
              value: "/uat"
            - name: RP_AMQP_PASS
              value: "rabbitmqpassword"
            - name: RP_AMQP_ADDRESSES
              value: 'amqp://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:5672'
            - name: RP_INITIAL_ADMIN_PASSWORD
              value: ""
            - name: RP_SAML_SESSION-LIVE
              value: "4320"
            - name: JAVA_OPTS
              value: "-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0 --add-opens=java.base/java.lang=ALL-UNNAMED"
            - name: RP_SESSION_LIVE
              value: "86400"
            - name: RP_DB_HOST
              value: reportportal-test-postgresql.eep-reportportal.svc.cluster.local
            - name: RP_DB_PORT
              value: "5432"
            - name: RP_DB_NAME
              value: "reportportal"
            - name: RP_DB_USER
              value: "postgres"
            - name: RP_DB_PASS
              value: "rppassword"
        # Datastore settings
            - name: DATASTORE_TYPE
              value: "minio"
        # Minio/S3 settings
            - name: DATASTORE_ENDPOINT
              value: "http://reportportal-test-minio.eep-reportportal.svc.cluster.local:9000"
            - name: DATASTORE_ACCESSKEY
              value: "rpuser"
            - name: DATASTORE_SECRETKEY
              value: "miniopassword"
            - name: DATASTORE_BUCKETPREFIX
              value: "prj-"
            - name: DATASTORE_BUCKETPOSTFIX
              value: ""
            - name: RP_INTEGRATION_SALT_PATH
              value: "keystore"
            - name: DATASTORE_DEFAULTBUCKETNAME
              value: "rp-bucket"
          readinessProbe:
            httpGet:
              path: "/uat/health"
              port: 9999
            initialDelaySeconds: 60
            periodSeconds: 40
            timeoutSeconds: 5
            failureThreshold: 10
          livenessProbe:
            tcpSocket:
              port: 9999
            initialDelaySeconds: 60
            periodSeconds: 40
            timeoutSeconds: 5
            failureThreshold: 10
          volumeMounts:
      securityContext:
        {}
      serviceAccountName: reportportal
      volumes:
---
# Source: reportportal/templates/service-index/index-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-index
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-index
  template:
    metadata:
      labels:
        component: reportportal-test-index
      annotations:
    spec:
      initContainers:
      serviceAccountName: reportportal
      containers:
      - name: index
        image: "reportportal/service-index:5.15.0"
        imagePullPolicy: "Always"
        env:
        - name: K8S_MODE
          value: "true"
        - name: RESOURCE_PATH
          value:
        ports:
        - containerPort: 8080
          protocol: TCP
        readinessProbe:
          httpGet:
            path: "/health"
            port: 8080
          initialDelaySeconds: 30
          periodSeconds: 10
          timeoutSeconds: 5
          failureThreshold: 3
          successThreshold: 1
        livenessProbe:
          tcpSocket:
            port: 8080
          initialDelaySeconds: 60
          periodSeconds: 30
          timeoutSeconds: 5
          failureThreshold: 3
        resources:
          requests:
            cpu: 150m
            memory: 128Mi
          limits:
            cpu: 200m
            memory: 256Mi
      securityContext:
        {}
---
# Source: reportportal/templates/service-jobs/jobs-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-jobs
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-jobs
  template:
    metadata:
      labels:
        component: reportportal-test-jobs
      annotations:
    spec:
      initContainers:
      - name: migrations-waiting-init
        image: "reportportal/k8s-wait-for:latest"
        imagePullPolicy: IfNotPresent
        args:
          - "job-wr"
          - reportportal-test-migrations
        resources:
          requests:
            cpu: 50m
            memory: 100Mi
          limits:
            cpu: 50m
            memory: 100Mi
      containers:
      - name: "jobs"
        image: "reportportal/service-jobs:5.15.0"
        imagePullPolicy: "Always"
        ports:
        - containerPort: 8686
          protocol: TCP
        resources:
          requests:
            cpu: 100m
            memory: 248Mi
          limits:
            cpu: 250m
            memory: 512Mi
        env:
        - name: SERVER_SERVLET_CONTEXT_PATH
          value: "/jobs"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_ATTACHMENT_CRON
          value: "0 0 */24 * * *"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_LOG_CRON
          value: "0 0 */24 * * *"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_LAUNCH_CRON
          value: "0 0 */24 * * *"
        - name: RP_ENVIRONMENT_VARIABLE_BATCH-SIZE
          value: "10000"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_STORAGE_CRON
          value: "0 0 */24 * * *"
        - name: RP_ENVIRONMENT_VARIABLE_STORAGE_PROJECT_CRON
          value: "0 */5 * * * *"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_EVENTS_RETENTIONPERIOD
          value: "365"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_EVENTS_CRON
          value: "0 0 */24 * * *"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_STORAGE_CHUNKSIZE
          value: "200000"
        - name: JAVA_OPTS
          value: "-Djava.security.egd=file:/dev/./urandom -XX:+UseG1GC -XX:+UseStringDeduplication -XX:G1ReservePercent=20 -XX:InitiatingHeapOccupancyPercent=60 -XX:MaxRAMPercentage=70.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
        # AMQP Settings
        - name: RP_AMQP_ANALYZER-VHOST
          value: "analyzer"
        - name: RP_AMQP_PASS
          value: "rabbitmqpassword"
        - name: RP_AMQP_API_ADDRESS
          value: http://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:15672/api
        - name: RP_AMQP_ADDRESSES
          value: 'amqp://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:5672'
        # Database settings
        - name: RP_DB_HOST
          value: reportportal-test-postgresql.eep-reportportal.svc.cluster.local
        - name: RP_DB_PORT
          value: "5432"
        - name: RP_DB_NAME
          value: "reportportal"
        - name: RP_DB_USER
          value: "postgres"
        - name: RP_DB_PASS
          value: "rppassword"
        # Storage settings
        - name: DATASTORE_TYPE
          value: "minio"
        - name: DATASTORE_ENDPOINT
          value: "http://reportportal-test-minio.eep-reportportal.svc.cluster.local:9000"
        - name: DATASTORE_ACCESSKEY
          value: "rpuser"
        - name: DATASTORE_SECRETKEY
          value: "miniopassword"
        - name: DATASTORE_BUCKETPREFIX
          value: "prj-"
        - name: DATASTORE_BUCKETPOSTFIX
          value: ""
        - name: RP_INTEGRATION_SALT_PATH
          value: "keystore"
        - name: DATASTORE_DEFAULTBUCKETNAME
          value: "rp-bucket"
        - name: RP_AMQP_MAXLOGCONSUMER
          value: "1"
        readinessProbe:
          httpGet:
            path: "/jobs/health"
            port: 8686
          initialDelaySeconds: 60
          periodSeconds: 40
          timeoutSeconds: 5
          failureThreshold: 10
        livenessProbe:
          tcpSocket:
            port: 8686
          initialDelaySeconds: 60
          periodSeconds: 40
          timeoutSeconds: 5
          failureThreshold: 10
        volumeMounts:
      securityContext:
        {}
      serviceAccountName: reportportal
      volumes:
---
# Source: reportportal/templates/service-ui/ui-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-ui
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-ui
  template:
    metadata:
      labels:
        component: reportportal-test-ui
      annotations:
    spec:
      initContainers:
      containers:
      - name: ui
        image: "reportportal/service-ui:5.15.0"
        imagePullPolicy: "Always"
        env:
        - name: RP_SERVER_PORT
          value: "8080"
        ports:
        - containerPort: 8080
          protocol: TCP
        resources:
          requests:
            cpu: 100m
            memory: 64Mi
          limits:
            cpu: 200m
            memory: 128Mi
        readinessProbe:
          httpGet:
            path: "/ui/health"
            port: 8080
          initialDelaySeconds: 30
          periodSeconds: 10
          timeoutSeconds: 5
          failureThreshold: 3
          successThreshold: 1
        livenessProbe:
          tcpSocket:
            port: 8080
          initialDelaySeconds: 60
          periodSeconds: 30
          timeoutSeconds: 5
          failureThreshold: 3
        volumeMounts:
      volumes:
      securityContext:
        {}
      serviceAccountName: reportportal
---
# Source: reportportal/charts/opensearch/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: opensearch-cluster-master
  labels:
    helm.sh/chart: opensearch-2.36.0
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "2.19.4"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: opensearch-cluster-master
  annotations:
    majorVersion: "2"
spec:
  serviceName: opensearch-cluster-master-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: opensearch
      app.kubernetes.io/instance: reportportal-test
  replicas: 1
  podManagementPolicy: Parallel
  updateStrategy:
    type: RollingUpdate
  volumeClaimTemplates:
  - metadata:
      name: opensearch-cluster-master
    spec:
      accessModes:
      - "ReadWriteOnce"
      resources:
        requests:
          storage: "8Gi"
  template:
    metadata:
      name: "opensearch-cluster-master"
      labels:
        helm.sh/chart: opensearch-2.36.0
        app.kubernetes.io/name: opensearch
        app.kubernetes.io/instance: reportportal-test
        app.kubernetes.io/version: "2.19.4"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: opensearch-cluster-master
      annotations:
        configchecksum: 489c005c0202a29844c2d245d092e76cc576db525cc618371deaf7a0c14d0ca
    spec:
      securityContext:
        fsGroup: 1000
        runAsUser: 1000
      automountServiceAccountToken: false
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 1
            podAffinityTerm:
              topologyKey: kubernetes.io/hostname
              labelSelector:
                matchExpressions:
                - key: app.kubernetes.io/instance
                  operator: In
                  values:
                  - reportportal-test
                - key: app.kubernetes.io/name
                  operator: In
                  values:
                  - opensearch
      terminationGracePeriodSeconds: 120
      volumes:
      - name: config
        configMap:
          name: opensearch-cluster-master-config
      - emptyDir: {}
        name: config-emptydir
      enableServiceLinks: true
      initContainers:
      - name: fsgroup-volume
        image: "busybox:latest"
        imagePullPolicy: "IfNotPresent"
        command: ['sh', '-c']
        args:
          - 'chown -R 1000:1000 /usr/share/opensearch/data'
        securityContext:
          runAsUser: 0
        resources:
          {}
        volumeMounts:
          - name: "opensearch-cluster-master"
            mountPath: /usr/share/opensearch/data
      - name: configfile
        image: "opensearchproject/opensearch:2.19.4"
        imagePullPolicy: "IfNotPresent"
        command:
        - sh
        - -c
        - |
          #!/usr/bin/env bash
          cp -r /tmp/configfolder/*  /tmp/config/
        securityContext:
          capabilities:
            drop:
            - ALL
          runAsNonRoot: true
          runAsUser: 1000
        resources:
          {}
        volumeMounts:
          - mountPath: /tmp/config/
            name: config-emptydir
          - name: config
            mountPath: /tmp/configfolder/opensearch.yml
            subPath: opensearch.yml
      containers:
      - name: "opensearch"
        securityContext:
          capabilities:
            drop:
            - ALL
          runAsNonRoot: true
          runAsUser: 1000

        image: "opensearchproject/opensearch:2.19.4"
        imagePullPolicy: "IfNotPresent"
        readinessProbe:
          failureThreshold: 3
          periodSeconds: 5
          tcpSocket:
            port: 9200
          timeoutSeconds: 3
        startupProbe:
          failureThreshold: 30
          initialDelaySeconds: 30
          periodSeconds: 10
          tcpSocket:
            port: 9200
          timeoutSeconds: 3
        ports:
        - name: http
          containerPort: 9200
        - name: transport
          containerPort: 9300
        - name: metrics
          containerPort: 9600
        resources:
          requests:
            cpu: 1000m
            memory: 100Mi
        env:
        - name: node.name
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        - name: discovery.seed_hosts
          value: "opensearch-cluster-master-headless"
        - name: cluster.name
          value: "opensearch-cluster"
        - name: network.host
          value: "0.0.0.0"
        - name: OPENSEARCH_JAVA_OPTS
          value: "-Xmx512M -Xms512M"
        - name: node.roles
          value: "master,ingest,data,remote_cluster_client,"
        - name: discovery.type
          value: "single-node"
        - name: DISABLE_INSTALL_DEMO_CONFIG
          value: "true"
        - name: DISABLE_SECURITY_PLUGIN
          value: "true"
        volumeMounts:
        - name: "opensearch-cluster-master"
          mountPath: /usr/share/opensearch/data
        - name: config-emptydir
          mountPath: /usr/share/opensearch/config/opensearch.yml
          subPath: opensearch.yml
---
# Source: reportportal/charts/postgresql/templates/primary/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
    app.kubernetes.io/component: primary
spec:
  replicas: 1
  serviceName: reportportal-test-postgresql-hl
  updateStrategy:
    rollingUpdate: {}
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: postgresql
      app.kubernetes.io/component: primary
  template:
    metadata:
      name: reportportal-test-postgresql
      labels:
        app.kubernetes.io/instance: reportportal-test
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: postgresql
        app.kubernetes.io/version: 17.5.0
        helm.sh/chart: postgresql-16.7.21
        app.kubernetes.io/component: primary
    spec:
      serviceAccountName: reportportal-test-postgresql

      automountServiceAccountToken: false
      affinity:
        podAffinity:

        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app.kubernetes.io/instance: reportportal-test
                    app.kubernetes.io/name: postgresql
                    app.kubernetes.io/component: primary
                topologyKey: kubernetes.io/hostname
              weight: 1
        nodeAffinity:

      securityContext:
        fsGroup: 1001
        fsGroupChangePolicy: Always
        supplementalGroups: []
        sysctls: []
      hostNetwork: false
      hostIPC: false
      containers:
        - name: postgresql
          image: docker.io/bitnamilegacy/postgresql:17.5.0-debian-12-r20
          imagePullPolicy: "IfNotPresent"
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsGroup: 1001
            runAsNonRoot: true
            runAsUser: 1001
            seLinuxOptions: {}
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: BITNAMI_DEBUG
              value: "false"
            - name: POSTGRESQL_PORT_NUMBER
              value: "5432"
            - name: POSTGRESQL_VOLUME_DIR
              value: "/bitnami/postgresql"
            - name: PGDATA
              value: "/bitnami/postgresql/data"
            # Authentication
            - name: POSTGRES_PASSWORD_FILE
              value: /opt/bitnami/postgresql/secrets/postgres-password
            - name: POSTGRES_DATABASE
              value: "reportportal"
            # LDAP
            - name: POSTGRESQL_ENABLE_LDAP
              value: "no"
            # TLS
            - name: POSTGRESQL_ENABLE_TLS
              value: "no"
            # Audit
            - name: POSTGRESQL_LOG_HOSTNAME
              value: "false"
            - name: POSTGRESQL_LOG_CONNECTIONS
              value: "false"
            - name: POSTGRESQL_LOG_DISCONNECTIONS
              value: "false"
            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
              value: "off"
            # Others
            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
              value: "error"
            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
              value: "pgaudit"
          ports:
            - name: tcp-postgresql
              containerPort: 5432
          livenessProbe:
            failureThreshold: 6
            initialDelaySeconds: 30
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
            exec:
              command:
                - /bin/sh
                - -c
                - exec pg_isready -U "postgres" -d "dbname=reportportal" -h 127.0.0.1 -p 5432
          readinessProbe:
            failureThreshold: 6
            initialDelaySeconds: 5
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
            exec:
              command:
                - /bin/sh
                - -c
                - -e
                - |
                  exec pg_isready -U "postgres" -d "dbname=reportportal" -h 127.0.0.1 -p 5432
          resources:
            limits:
              cpu: 150m
              ephemeral-storage: 2Gi
              memory: 192Mi
            requests:
              cpu: 100m
              ephemeral-storage: 50Mi
              memory: 128Mi
          volumeMounts:
            - name: empty-dir
              mountPath: /tmp
              subPath: tmp-dir
            - name: empty-dir
              mountPath: /opt/bitnami/postgresql/conf
              subPath: app-conf-dir
            - name: empty-dir
              mountPath: /opt/bitnami/postgresql/tmp
              subPath: app-tmp-dir
            - name: postgresql-password
              mountPath: /opt/bitnami/postgresql/secrets/
            - name: dshm
              mountPath: /dev/shm
            - name: data
              mountPath: /bitnami/postgresql
      volumes:
        - name: empty-dir
          emptyDir: {}
        - name: postgresql-password
          secret:
            secretName: reportportal-test-postgresql
        - name: dshm
          emptyDir:
            medium: Memory
  volumeClaimTemplates:
    - apiVersion: v1
      kind: PersistentVolumeClaim
      metadata:
        name: data
      spec:
        accessModes:
          - "ReadWriteOnce"
        resources:
          requests:
            storage: "8Gi"
---
# Source: reportportal/charts/rabbitmq/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
spec:
  serviceName: reportportal-test-rabbitmq-headless
  podManagementPolicy: OrderedReady
  replicas: 1
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: rabbitmq
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: reportportal-test
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: rabbitmq
        app.kubernetes.io/version: 4.1.2
        helm.sh/chart: rabbitmq-16.0.11
      annotations:
        checksum/config: 98524157265f953be9e946b8b194231674bf7fe7f0188dee9d92fcb9f552a278
        checksum/secret: 656cdb19a6f040043cbcdf3472ed2394840619ce41f414dc363e2d6eab2afd93
    spec:

      serviceAccountName: reportportal-test-rabbitmq
      affinity:
        podAffinity:

        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app.kubernetes.io/instance: reportportal-test
                    app.kubernetes.io/name: rabbitmq
                topologyKey: kubernetes.io/hostname
              weight: 1
        nodeAffinity:

      automountServiceAccountToken: true
      securityContext:
        fsGroup: 1001
        fsGroupChangePolicy: Always
        supplementalGroups: []
        sysctls: []
      terminationGracePeriodSeconds: 120
      enableServiceLinks: true
      initContainers:
        - name: prepare-plugins-dir
          image: docker.io/bitnamilegacy/rabbitmq:4.1.2-debian-12-r1
          imagePullPolicy: "IfNotPresent"
          resources:
            limits:
              cpu: 375m
              ephemeral-storage: 2Gi
              memory: 384Mi
            requests:
              cpu: 250m
              ephemeral-storage: 50Mi
              memory: 256Mi
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsGroup: 1001
            runAsNonRoot: true
            runAsUser: 1001
            seLinuxOptions: {}
            seccompProfile:
              type: RuntimeDefault
          command:
            - /bin/bash
          args:
            - -ec
            - |
              #!/bin/bash

              . /opt/bitnami/scripts/liblog.sh

              info "Copying plugins dir to empty dir"
              # In order to not break the possibility of installing custom plugins, we need
              # to make the plugins directory writable, so we need to copy it to an empty dir volume
              cp -r --preserve=mode /opt/bitnami/rabbitmq/plugins/ /emptydir/app-plugins-dir
          volumeMounts:
            - name: empty-dir
              mountPath: /emptydir
      containers:
        - name: rabbitmq
          image: docker.io/bitnamilegacy/rabbitmq:4.1.2-debian-12-r1
          imagePullPolicy: "IfNotPresent"
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsGroup: 1001
            runAsNonRoot: true
            runAsUser: 1001
            seLinuxOptions: {}
            seccompProfile:
              type: RuntimeDefault
          lifecycle:
            preStop:
              exec:
                command:
                  - /bin/bash
                  - -ec
                  - |
                    if [[ -f /opt/bitnami/scripts/rabbitmq/nodeshutdown.sh ]]; then
                        /opt/bitnami/scripts/rabbitmq/nodeshutdown.sh -t "120" -d "false"
                    else
                        rabbitmqctl stop_app
                    fi
          env:
            - name: BITNAMI_DEBUG
              value: "false"
            - name: MY_POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
            - name: MY_POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: MY_POD_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: RABBITMQ_FORCE_BOOT
              value: "no"
            - name: RABBITMQ_NODE_NAME
              value: "rabbit@$(MY_POD_NAME).reportportal-test-rabbitmq-headless.$(MY_POD_NAMESPACE).svc.cluster.local"
            - name: RABBITMQ_UPDATE_PASSWORD
              value: "no"
            - name: RABBITMQ_MNESIA_DIR
              value: "/opt/bitnami/rabbitmq/.rabbitmq/mnesia/$(RABBITMQ_NODE_NAME)"
            - name: RABBITMQ_LDAP_ENABLE
              value: "no"
            - name: RABBITMQ_LOGS
              value: "-"
            - name: RABBITMQ_ULIMIT_NOFILES
              value: "65535"
            - name: RABBITMQ_USE_LONGNAME
              value: "true"
            - name: RABBITMQ_ERL_COOKIE_FILE
              value: /opt/bitnami/rabbitmq/secrets/rabbitmq-erlang-cookie
            - name: RABBITMQ_LOAD_DEFINITIONS
              value: "no"
            - name: RABBITMQ_DEFINITIONS_FILE
              value: "/app/load_definition.json"
            - name: RABBITMQ_SECURE_PASSWORD
              value: "yes"
            - name: RABBITMQ_USERNAME
              value: "rabbitmq"
            - name: RABBITMQ_PASSWORD_FILE
              value: /opt/bitnami/rabbitmq/secrets/rabbitmq-password
            - name: RABBITMQ_PLUGINS
              value: "rabbitmq_management, rabbitmq_peer_discovery_k8s, rabbitmq_auth_backend_ldap, rabbitmq_consistent_hash_exchange, rabbitmq_shovel, rabbitmq_shovel_management\n"
          envFrom:
          ports:
            - name: amqp
              containerPort: 5672
            - name: dist
              containerPort: 25672
            - name: stats
              containerPort: 15672
            - name: epmd
              containerPort: 4369
            - name: metrics
              containerPort: 9419
          livenessProbe:
            failureThreshold: 6
            initialDelaySeconds: 120
            periodSeconds: 30
            successThreshold: 1
            timeoutSeconds: 20
            exec:
              command:
                - /bin/bash
                - -ec
                - curl -f --user rabbitmq:$(< $RABBITMQ_PASSWORD_FILE) 127.0.0.1:15672/api/health/checks/virtual-hosts
          readinessProbe:
            failureThreshold: 3
            initialDelaySeconds: 10
            periodSeconds: 30
            successThreshold: 1
            timeoutSeconds: 20
            exec:
              command:
                - /bin/bash
                - -ec
                - curl -f --user rabbitmq:$(< $RABBITMQ_PASSWORD_FILE) 127.0.0.1:15672/api/health/checks/local-alarms
          resources:
            limits:
              cpu: 375m
              ephemeral-storage: 2Gi
              memory: 384Mi
            requests:
              cpu: 250m
              ephemeral-storage: 50Mi
              memory: 256Mi
          volumeMounts:
            - name: configuration
              mountPath: /bitnami/rabbitmq/conf
            - name: empty-dir
              mountPath: /tmp
              subPath: tmp-dir
            - name: empty-dir
              mountPath: /opt/bitnami/rabbitmq/etc/rabbitmq
              subPath: app-conf-dir
            - name: empty-dir
              mountPath: /opt/bitnami/rabbitmq/var/lib/rabbitmq
              subPath: app-tmp-dir
            - name: empty-dir
              mountPath: /opt/bitnami/rabbitmq/.rabbitmq/
              subPath: app-erlang-cookie
            - name: empty-dir
              mountPath: /opt/bitnami/rabbitmq/var/log/rabbitmq
              subPath: app-logs-dir
            - name: empty-dir
              mountPath: /opt/bitnami/rabbitmq/plugins
              subPath: app-plugins-dir
            - name: data
              mountPath: /opt/bitnami/rabbitmq/.rabbitmq/mnesia
            - name: rabbitmq-secrets
              mountPath: /opt/bitnami/rabbitmq/secrets
      volumes:
        - name: empty-dir
          emptyDir: {}
        - name: configuration
          projected:
            sources:
              - secret:
                  name: reportportal-test-rabbitmq-config
        - name: rabbitmq-secrets
          projected:
            sources:
              - secret:
                  name: reportportal-test-rabbitmq
              - secret:
                  name: reportportal-test-rabbitmq
  volumeClaimTemplates:
    - apiVersion: v1
      kind: PersistentVolumeClaim
      metadata:
        name: data
        labels:
          app.kubernetes.io/instance: reportportal-test
          app.kubernetes.io/name: rabbitmq
      spec:
        accessModes:
            - "ReadWriteOnce"
        resources:
          requests:
            storage: "8Gi"
---
# Source: reportportal/templates/service-auto-analyzer/analyzer-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: reportportal-test-analyzer
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-analyzer
  serviceName: reportportal-test-analyzer
  template:
    metadata:
      labels:
        component: reportportal-test-analyzer
      annotations:
    spec:
      initContainers:
      - name: migrations-waiting-init
        image: "reportportal/k8s-wait-for:latest"
        imagePullPolicy: IfNotPresent
        args:
          - "pod-wr"
          - "-lcomponent=reportportal-test-api"
        resources:
          requests:
            cpu: 50m
            memory: 100Mi
          limits:
            cpu: 50m
            memory: 100Mi
      containers:
      - name: "analyzer"
        image: "reportportal/service-auto-analyzer:5.15.0"
        imagePullPolicy: "Always"
        ports:
        - containerPort: 5001
          name: analyzercore
        resources:
          limits:
            cpu: 500m
            memory: 1Gi
          requests:
            cpu: 500m
            memory: 512Mi
        env:
        - name: DATASTORE_TYPE
          value: "minio"
        - name: DATASTORE_ENDPOINT
          value: "http://reportportal-test-minio.eep-reportportal.svc.cluster.local:9000"
        - name: DATASTORE_ACCESSKEY
          value: "rpuser"
        - name: DATASTORE_SECRETKEY
          value: "miniopassword"
        - name: DATASTORE_BUCKETPREFIX
          value: "prj-"
        - name: DATASTORE_BUCKETPOSTFIX
          value: ""
        - name: DATASTORE_DEFAULTBUCKETNAME
          value: "rp-bucket/analyzer"
        - name: RP_AMQP_PASS
          value: "rabbitmqpassword"
        - name: AMQP_URL
          value: amqp://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:5672/
        - name: AMQP_EXCHANGE_NAME
          value: "analyzer-default"
        - name: AMQP_VIRTUAL_HOST
          value: "analyzer"
        - name: ES_HOSTS
          value: "http://opensearch-cluster-master.eep-reportportal.svc.cluster.local:9200"
        - name: ES_USER
          value: ""
        - name: ES_PASSWORD
          value: ""
        - name: UWSGI_WORKERS
          value: "2"
        readinessProbe:
          httpGet:
            path: /
            port: 5001
          initialDelaySeconds: 30
          periodSeconds: 10
          timeoutSeconds: 5
          failureThreshold: 3
          successThreshold: 1
        livenessProbe:
          tcpSocket:
            port: 5001
          initialDelaySeconds: 60
          periodSeconds: 30
          timeoutSeconds: 10
          failureThreshold: 3
          successThreshold: 1
        volumeMounts:
      securityContext:
        {}
      serviceAccountName: reportportal
---
# Source: reportportal/templates/service-migrations/migrations-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: reportportal-test-migrations
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  template:
    metadata:
      labels:
        component: reportportal-test-migrations
      annotations:
    spec:
      restartPolicy: OnFailure
      containers:
      - env:
        - name: POSTGRES_SSLMODE
          value: "disable"
        - name: POSTGRES_SERVER
          value: reportportal-test-postgresql.eep-reportportal.svc.cluster.local
        - name: POSTGRES_DB
          value: "reportportal"
        - name: POSTGRES_PORT
          value: "5432"
        - name: POSTGRES_USER
          value: "postgres"
        - name: POSTGRES_PASSWORD

          value: "rppassword"

        image: "reportportal/migrations:5.15.0"
        imagePullPolicy: "Always"
        name: migrations
        resources:
          requests:
            cpu: 100m
            memory: 128Mi
          limits:
            cpu: 100m
            memory: 128Mi
      securityContext:
        {}
      serviceAccountName: reportportal
---
# Source: reportportal/templates/ingress/gateway-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: reportportal-test-gateway-ingress
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
spec:
  ingressClassName: nginx
  # Define the TLS settings
  # Define the rules for the ingress
  rules:
  - http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: reportportal-test-index
            port:
              name: headless
      - path: /ui
        pathType: Prefix
        backend:
          service:
            name: reportportal-test-ui
            port:
              name: headless
      - path: /uat
        pathType: Prefix
        backend:
          service:
            name: reportportal-test-uat
            port:
              name: headless
      - path: /api
        pathType: Prefix
        backend:
          service:
            name: reportportal-test-api
            port:
              name: headless
status:
  loadBalancer: {}
---
# Source: reportportal/templates/volumes/pv.yaml
# This snippet creates a PersistentVolume when ReportPortal uses
# filesystem as a storage type instead of a bucket.
# If you set a type of volume to 'gcp' or 'aws' in values.yaml
# this snippet won't be used for creating a PersistentVolume.
# GCP and AWS provides dynamic provisioning of volumes.
# However, you can use a CSI type to get an access to pre-existing volumes.
---
# Source: reportportal/templates/hooks/tests/readiness-test.yaml
apiVersion: v1
kind: Pod
metadata:
  name: reportportal-test-readiness-test
  labels:


    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    "helm.sh/hook": test
spec:
  containers:
  - name: test-container
    image: "curlimages/curl:latest"
    command: ["/bin/sh", "-c"]
    args:
    - >
      for url in \
        "http://reportportal-test-index:8080/health" \
        "http://reportportal-test-ui:8080/ui/health" \
        "http://reportportal-test-api:8585/api/health" \
        "http://reportportal-test-uat:9999/uat/health" \
        "http://reportportal-test-jobs:8686/jobs/health"
      do
        echo "Checking $url";
        response=$(curl --write-out "%{http_code}" --silent --output /dev/null $url);
        if [ $response -ne 200 ]; then
          echo "Health check failed for $url with response code $response";
          exit 1;
        else
          echo "Health check succeeded for $url";
        fi;
      done;
      echo "All health checks passed.";
    resources:
      limits:
        cpu: 100m
        memory: 128Mi
      requests:
        cpu: 50m
        memory: 64Mi
  restartPolicy: Never
---
# Source: reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: reportportal-test-pre-upgrade-cleanup
  labels:

    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    "helm.sh/hook": pre-upgrade
    "helm.sh/hook-delete-policy": hook-succeeded
spec:
  template:
    metadata:
      labels:
        component: reportportal-test-pre-upgrade-cleanup
      annotations:
    spec:
      serviceAccountName: reportportal
      restartPolicy: OnFailure
      containers:
      - name: delete-job
        image: "bitnamisecure/kubectl:latest"
        command:
        - /bin/sh
        - -c
        - |
          kubectl delete job reportportal-test-migrations --ignore-not-found=true
        resources:
          limits:
            cpu: 100m
            memory: 128Mi
          requests:
            cpu: 50m
            memory: 64Mi
```

</p>
</details>  

<details><summary>Template Validation (Default Configuration)</summary>
<p>

```
helm template reportportal-test ./reportportal \
  --set uat.superadminInitPasswd.password="testpassword123" \
  --set postgresql.install=true \
  --set rabbitmq.install=true \
  --set opensearch.install=true \
  --set minio.install=true
level=INFO msg="warning: destination for rabbitmq.ingress.tls is a table. Ignoring non-table value (false)"
level=INFO msg="warning: destination for minio.ingress.tls is a table. Ignoring non-table value (false)"
---
# Source: reportportal/charts/minio/templates/networkpolicy.yaml
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: minio
      app.kubernetes.io/component: minio
      app.kubernetes.io/part-of: minio
  policyTypes:
    - Ingress
    - Egress
  egress:
    - {}
  ingress:
    # Allow inbound connections
    - ports:
        - port: 9000
---
# Source: reportportal/charts/postgresql/templates/primary/networkpolicy.yaml
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
    app.kubernetes.io/component: primary
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: postgresql
      app.kubernetes.io/component: primary
  policyTypes:
    - Ingress
    - Egress
  egress:
    - {}
  ingress:
    - ports:
        - port: 5432
---
# Source: reportportal/charts/rabbitmq/templates/networkpolicy.yaml
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: rabbitmq
  policyTypes:
    - Ingress
    - Egress
  egress:
    - {}
  ingress:
    # Allow inbound connections to RabbitMQ
    - ports:
        - port: 4369
        - port: 5672
        - port: 5671
        - port: 25672
        - port: 15672
---
# Source: reportportal/charts/minio/templates/pdb.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: minio
      app.kubernetes.io/component: minio
      app.kubernetes.io/part-of: minio
---
# Source: reportportal/charts/opensearch/templates/poddisruptionbudget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: "opensearch-cluster-master-pdb"
  labels:
    helm.sh/chart: opensearch-2.36.0
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "2.19.4"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: opensearch-cluster-master
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: opensearch
      app.kubernetes.io/instance: reportportal-test
---
# Source: reportportal/charts/postgresql/templates/primary/pdb.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
    app.kubernetes.io/component: primary
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: postgresql
      app.kubernetes.io/component: primary
---
# Source: reportportal/charts/rabbitmq/templates/pdb.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: rabbitmq
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-index-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-index
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-ui-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-ui
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-api-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-api
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-uat-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-uat
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-jobs-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-jobs
---
# Source: reportportal/templates/pod-disruption-budget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: reportportal-test-analyzer-pdb
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      component: reportportal-test-analyzer
---
# Source: reportportal/charts/minio/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/part-of: minio
automountServiceAccountToken: false
secrets:
  - name: reportportal-test-minio
---
# Source: reportportal/charts/postgresql/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
automountServiceAccountToken: false
---
# Source: reportportal/charts/rabbitmq/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
automountServiceAccountToken: false
secrets:
  - name: reportportal-test-rabbitmq
---
# Source: reportportal/templates/authorization/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
    name: reportportal
    namespace: eep-reportportal
    annotations:
---
# Source: reportportal/charts/minio/templates/secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
type: Opaque
data:
  root-user: "cnB1c2Vy"
  root-password: "xxxxxxx=="
---
# Source: reportportal/charts/postgresql/templates/secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
type: Opaque
data:
  postgres-password: "xxxxx=="
  # We don't auto-generate LDAP password when it's not provided as we do for other passwords
---
# Source: reportportal/charts/rabbitmq/templates/config-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: reportportal-test-rabbitmq-config
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
type: Opaque
data:
  rabbitmq.conf: |-
    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCmRlZmF1bHRfdXNlciA9IHJhYmJpdG1xCiMjIENsdXN0ZXJpbmcKIyMKY2x1c3Rlcl9uYW1lID0gcmVwb3J0cG9ydGFsLXRlc3QtcmFiYml0bXEKY2x1c3Rlcl9mb3JtYXRpb24ucGVlcl9kaXNjb3ZlcnlfYmFja2VuZCAgPSByYWJiaXRfcGVlcl9kaXNjb3ZlcnlfazhzCmNsdXN0ZXJfZm9ybWF0aW9uLms4cy5ob3N0ID0ga3ViZXJuZXRlcy5kZWZhdWx0CmNsdXN0ZXJfZm9ybWF0aW9uLms4cy5hZGRyZXNzX3R5cGUgPSBob3N0bmFtZQpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuc2VydmljZV9uYW1lID0gcmVwb3J0cG9ydGFsLXRlc3QtcmFiYml0bXEtaGVhZGxlc3MKY2x1c3Rlcl9mb3JtYXRpb24uazhzLmhvc3RuYW1lX3N1ZmZpeCA9IC5yZXBvcnRwb3J0YWwtdGVzdC1yYWJiaXRtcS1oZWFkbGVzcy5lZXAtcmVwb3J0cG9ydGFsLnN2Yy5jbHVzdGVyLmxvY2FsCmNsdXN0ZXJfZm9ybWF0aW9uLm5vZGVfY2xlYW51cC5pbnRlcnZhbCA9IDEwCmNsdXN0ZXJfZm9ybWF0aW9uLm5vZGVfY2xlYW51cC5vbmx5X2xvZ193YXJuaW5nID0gdHJ1ZQpjbHVzdGVyX3BhcnRpdGlvbl9oYW5kbGluZyA9IGF1dG9oZWFsCgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgbG9vcGJhY2sgdXNlcgpsb29wYmFja191c2Vycy5yYWJiaXRtcSA9IGZhbHNlCm1heF9tZXNzYWdlX3NpemUgPSAxMzQyMTc3MjgKIyMgUHJvbWV0aGV1cyBtZXRyaWNzCiMjCnByb21ldGhldXMudGNwLnBvcnQgPSA5NDE5CiMjIFRDUCBMaXN0ZW4gT3B0aW9ucwojIwp0Y3BfbGlzdGVuX29wdGlvbnMuYmFja2xvZyA9IDEyOAp0Y3BfbGlzdGVuX29wdGlvbnMubm9kZWxheSA9IHRydWUKdGNwX2xpc3Rlbl9vcHRpb25zLmxpbmdlci5vbiAgICAgID0gdHJ1ZQp0Y3BfbGlzdGVuX29wdGlvbnMubGluZ2VyLnRpbWVvdXQgPSAwCnRjcF9saXN0ZW5fb3B0aW9ucy5rZWVwYWxpdmUgPSBmYWxzZQ==
---
# Source: reportportal/charts/rabbitmq/templates/secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
type: Opaque
data:
  rabbitmq-password: "xxxxx=="
  rabbitmq-erlang-cookie: "dmJqNDNWOExua3A0R3h0c1NaM1AzNEg3dUN5U1B4R1c="
---
# Source: reportportal/templates/service-authorization/uat-init-password.yaml
apiVersion: v1
kind: Secret
metadata:
  name: reportportal-uat-init-password
  namespace: eep-reportportal
  labels:

    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
data:
  password: "dGVzdHBhc3N3b3JkMTIz"
---
# Source: reportportal/charts/opensearch/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: opensearch-cluster-master-config
  labels:
    helm.sh/chart: opensearch-2.36.0
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "2.19.4"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: opensearch-cluster-master
data:
  opensearch.yml: |
    cluster.name: opensearch-cluster

    # Bind to all interfaces because we don't know what IP address Docker will assign to us.
    network.host: 0.0.0.0

    # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
    # Implicitly done if ".singleNode" is set to "true".
    # discovery.type: single-node

    # Start OpenSearch Security Demo Configuration
    # WARNING: revise all the lines below before you go into production
    # plugins:
    #   security:
    #     ssl:
    #       transport:
    #         pemcert_filepath: esnode.pem
    #         pemkey_filepath: esnode-key.pem
    #         pemtrustedcas_filepath: root-ca.pem
    #         enforce_hostname_verification: false
    #       http:
    #         enabled: true
    #         pemcert_filepath: esnode.pem
    #         pemkey_filepath: esnode-key.pem
    #         pemtrustedcas_filepath: root-ca.pem
    #     allow_unsafe_democertificates: true
    #     allow_default_init_securityindex: true
    #     authcz:
    #       admin_dn:
    #         - CN=kirk,OU=client,O=client,L=test,C=de
    #     audit.type: internal_opensearch
    #     enable_snapshot_restore_privilege: true
    #     check_snapshot_restore_write_privileges: true
    #     restapi:
    #       roles_enabled: ["all_access", "security_rest_api_access"]
    #     system_indices:
    #       enabled: true
    #       indices:
    #         [
    #           ".opendistro-alerting-config",
    #           ".opendistro-alerting-alert*",
    #           ".opendistro-anomaly-results*",
    #           ".opendistro-anomaly-detector*",
    #           ".opendistro-anomaly-checkpoints",
    #           ".opendistro-anomaly-detection-state",
    #           ".opendistro-reports-*",
    #           ".opendistro-notifications-*",
    #           ".opendistro-notebooks",
    #           ".opendistro-asynchronous-search-response*",
    #         ]
    ######## End OpenSearch Security Demo Configuration ########
---
# Source: reportportal/charts/minio/templates/pvc.yaml
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
  annotations:
    helm.sh/resource-policy: keep
spec:
  accessModes:
    - "ReadWriteOnce"
  resources:
    requests:
      storage: "8Gi"
---
# Source: reportportal/charts/rabbitmq/templates/role.yaml
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: reportportal-test-rabbitmq-endpoint-reader
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
rules:
  - apiGroups: [""]
    resources: ["endpoints"]
    verbs: ["get"]
  - apiGroups: [""]
    resources: ["events"]
    verbs: ["create"]
---
# Source: reportportal/templates/authorization/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: reportportal-test-service-manager
  namespace: eep-reportportal
  annotations:
rules:
  # Allow the service account to get and list pods, services, and jobs
  - apiGroups: ["", "batch"]
    resources: ["pods","services", "jobs"]
    verbs: ["get", "list", "watch"]
  # Allow the service account to delete jobs
  - apiGroups: ["batch"]
    resources: ["jobs"]
    verbs: ["delete"]
---
# Source: reportportal/charts/rabbitmq/templates/rolebinding.yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: reportportal-test-rabbitmq-endpoint-reader
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
subjects:
  - kind: ServiceAccount
    name: reportportal-test-rabbitmq
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: reportportal-test-rabbitmq-endpoint-reader
---
# Source: reportportal/templates/authorization/rolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: reportportal-test-user-binding
  namespace: eep-reportportal
  annotations:
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: reportportal-test-service-manager
subjects:
  - kind: ServiceAccount
    name: reportportal
    namespace: eep-reportportal
---
# Source: reportportal/charts/minio/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
spec:
  type: ClusterIP
  ports:
    - name: tcp-api
      port: 9000
      targetPort: api
      nodePort: null
  selector:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/name: minio
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
---
# Source: reportportal/charts/opensearch/templates/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: opensearch-cluster-master
  labels:
    helm.sh/chart: opensearch-2.36.0
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "2.19.4"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: opensearch-cluster-master
  annotations:
    {}
spec:
  type: ClusterIP
  selector:
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
  ports:
  - name: http
    protocol: TCP
    port: 9200
  - name: transport
    protocol: TCP
    port: 9300
  - name: metrics
    protocol: TCP
    port: 9600
---
# Source: reportportal/charts/opensearch/templates/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: opensearch-cluster-master-headless
  labels:
    helm.sh/chart: opensearch-2.36.0
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "2.19.4"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: opensearch-cluster-master
  annotations:
    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
spec:
  clusterIP: None # This is needed for statefulset hostnames like opensearch-0 to resolve
  # Create endpoints also if the related pod isn't ready
  publishNotReadyAddresses: true
  selector:
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
  ports:
  - name: http
    port: 9200
  - name: transport
    port: 9300
  - name: metrics
    port: 9600
---
# Source: reportportal/charts/postgresql/templates/primary/svc-headless.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-postgresql-hl
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
    app.kubernetes.io/component: primary
  annotations:
spec:
  type: ClusterIP
  clusterIP: None
  # We want all pods in the StatefulSet to have their addresses published for
  # the sake of the other Postgresql pods even before they're ready, since they
  # have to be able to talk to each other in order to become ready.
  publishNotReadyAddresses: true
  ports:
    - name: tcp-postgresql
      port: 5432
      targetPort: tcp-postgresql
  selector:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/component: primary
---
# Source: reportportal/charts/postgresql/templates/primary/svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
    app.kubernetes.io/component: primary
spec:
  type: ClusterIP
  sessionAffinity: None
  ports:
    - name: tcp-postgresql
      port: 5432
      targetPort: tcp-postgresql
      nodePort: null
  selector:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/component: primary
---
# Source: reportportal/charts/rabbitmq/templates/svc-headless.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-rabbitmq-headless
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
spec:
  clusterIP: None
  ports:
    - name: epmd
      port: 4369
      targetPort: epmd
    - name: amqp
      port: 5672
      targetPort: amqp
    - name: dist
      port: 25672
      targetPort: dist
    - name: http-stats
      port: 15672
      targetPort: stats
  selector:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/name: rabbitmq
  publishNotReadyAddresses: true
  trafficDistribution: PreferClose
---
# Source: reportportal/charts/rabbitmq/templates/svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
spec:
  type: ClusterIP
  sessionAffinity: None
  ports:
    - name: amqp
      port: 5672
      targetPort: amqp
      nodePort: null
    - name: epmd
      port: 4369
      targetPort: epmd
      nodePort: null
    - name: dist
      port: 25672
      targetPort: dist
      nodePort: null
    - name: http-stats
      port: 15672
      targetPort: stats
      nodePort: null
  selector:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/name: rabbitmq
---
# Source: reportportal/templates/service-api/api-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-api
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    service: api
    infoEndpoint: "/api/info"
    healthEndpoint: "/api/health"
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 8585
    protocol: TCP
    targetPort: 8585
  selector:
    component: reportportal-test-api
---
# Source: reportportal/templates/service-authorization/uat-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-uat
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    service: uat
    infoEndpoint: "/uat/info"
    healthEndpoint: "/uat/health"
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 9999
    protocol: TCP
    targetPort: 9999
  selector:
    component: reportportal-test-uat
---
# Source: reportportal/templates/service-auto-analyzer/analyzer-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-analyzer
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 8080
    protocol: TCP
    targetPort: analyzercore
  selector:
    component: reportportal-test-analyzer
---
# Source: reportportal/templates/service-index/index-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-index
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    service: index
    infoEndpoint: "/info"
    healthEndpoint: "/health"
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 8080
    protocol: TCP
    targetPort: 8080
  selector:
    component: reportportal-test-index
---
# Source: reportportal/templates/service-jobs/jobs-services.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-jobs
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    service: jobs
    infoEndpoint: "/jobs/info"
    healthEndpoint: "/jobs/health"
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 8686
    protocol: TCP
    targetPort: 8686
  selector:
    component: reportportal-test-jobs
---
# Source: reportportal/templates/service-ui/ui-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: reportportal-test-ui
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    service: ui
    infoEndpoint: "/ui/info"
    healthEndpoint: "/ui/health"
spec:
  type: ClusterIP
  ports:
  - name: headless
    port: 8080
    protocol: TCP
    targetPort: 8080
  selector:
    component: reportportal-test-ui
---
# Source: reportportal/charts/minio/templates/application.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-minio
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: minio
    app.kubernetes.io/version: 2025.7.23
    helm.sh/chart: minio-17.0.16
    app.kubernetes.io/component: minio
    app.kubernetes.io/part-of: minio
spec:
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: minio
      app.kubernetes.io/component: minio
      app.kubernetes.io/part-of: minio
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: reportportal-test
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: minio
        app.kubernetes.io/version: 2025.7.23
        helm.sh/chart: minio-17.0.16
        app.kubernetes.io/component: minio
        app.kubernetes.io/part-of: minio
      annotations:
        checksum/credentials-secret: 5f596bf1fd096880282979a69bf3aac6a9317fc784b1cfd07648236561312a76
    spec:

      serviceAccountName: reportportal-test-minio
      affinity:
        podAffinity:

        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app.kubernetes.io/instance: reportportal-test
                    app.kubernetes.io/name: minio
                    app.kubernetes.io/component: minio
                topologyKey: kubernetes.io/hostname
              weight: 1
        nodeAffinity:

      automountServiceAccountToken: false
      securityContext:
        fsGroup: 1001
        fsGroupChangePolicy: OnRootMismatch
        supplementalGroups: []
        sysctls: []
      initContainers:
      containers:
        - name: minio
          image: docker.io/bitnamilegacy/minio:2025.7.23-debian-12-r0
          imagePullPolicy: "IfNotPresent"
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsGroup: 1001
            runAsNonRoot: true
            runAsUser: 1001
            seLinuxOptions: {}
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: BITNAMI_DEBUG
              value: "false"
            - name: MINIO_DISTRIBUTED_MODE_ENABLED
              value: "no"
            - name: MINIO_SCHEME
              value: "http"
            - name: MINIO_FORCE_NEW_KEYS
              value: "no"
            - name: MINIO_ROOT_USER_FILE
              value: /opt/bitnami/minio/secrets/root-user
            - name: MINIO_ROOT_PASSWORD_FILE
              value: /opt/bitnami/minio/secrets/root-password
            - name: MINIO_SKIP_CLIENT
              value: "yes"
            - name: MINIO_API_PORT_NUMBER
              value: "9000"
            - name: MINIO_BROWSER
              value: "off"
            - name: MINIO_PROMETHEUS_AUTH_TYPE
              value: "public"
            - name: MINIO_DATA_DIR
              value: "/bitnami/minio/data"
          ports:
            - name: api
              containerPort: 9000
          livenessProbe:
            httpGet:
              path: /minio/health/live
              port: api
              scheme: "HTTP"
            initialDelaySeconds: 5
            periodSeconds: 5
            timeoutSeconds: 5
            successThreshold: 1
            failureThreshold: 5
          readinessProbe:
            tcpSocket:
              port: api
            initialDelaySeconds: 5
            periodSeconds: 5
            timeoutSeconds: 1
            successThreshold: 1
            failureThreshold: 5
          resources:
            limits:
              cpu: 375m
              ephemeral-storage: 2Gi
              memory: 384Mi
            requests:
              cpu: 250m
              ephemeral-storage: 50Mi
              memory: 256Mi
          volumeMounts:
            - name: empty-dir
              mountPath: /tmp
              subPath: tmp-dir
            - name: empty-dir
              mountPath: /opt/bitnami/minio/tmp
              subPath: app-tmp-dir
            - name: empty-dir
              mountPath: /.mc
              subPath: app-mc-dir
            - name: minio-credentials
              mountPath: /opt/bitnami/minio/secrets/
            - name: data
              mountPath: /bitnami/minio/data
      volumes:
        - name: empty-dir
          emptyDir: {}
        - name: minio-credentials
          secret:
            secretName: reportportal-test-minio
        - name: data
          persistentVolumeClaim:
            claimName: reportportal-test-minio
---
# Source: reportportal/templates/service-api/api-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-api
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-api
  template:
    metadata:
      labels:
        component: reportportal-test-api
      annotations:
    spec:
      initContainers:
        - name: migrations-waiting-init
          image: "reportportal/k8s-wait-for:latest"
          imagePullPolicy: IfNotPresent
          args:
            - "job-wr"
            - reportportal-test-migrations
          resources:
            requests:
              cpu: 50m
              memory: 100Mi
            limits:
              cpu: 50m
              memory: 100Mi
      containers:
        - name: "api"
          image: "reportportal/service-api:5.15.0"
          imagePullPolicy: "Always"
          ports:
            - containerPort: 8585
              protocol: TCP
          resources:
            limits:
              cpu: 1000m
              memory: 2Gi
            requests:
              cpu: 500m
              memory: 1Gi
          env:
            - name: SERVER_SERVLET_CONTEXT_PATH
              value: "/api"
            - name: COM_TA_REPORTPORTAL_JOB_LOAD_PLUGINS_CRON
              value: "PT10S"
            - name: RP_JOBS_BASEURL
              value: http://reportportal-test-jobs.eep-reportportal.svc.cluster.local:8686/jobs
            - name: COM_TA_REPORTPORTAL_JOB_INTERRUPT_BROKEN_LAUNCHES_CRON
              value: "PT1H"
            - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_BATCH-SIZE
              value: "100"
            - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_PREFETCH-COUNT
              value: "1"
            - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_CONSUMERS-COUNT
              value: "1"
            - name: RP_ENVIRONMENT_VARIABLE_ALLOW_DELETE_ACCOUNT
              value: "true"
            - name: LOGGING_LEVEL_ORG_HIBERNATE_SQL
              value: "info"
            - name: RP_REQUESTLOGGING
              value: "false"
            - name: JAVA_OPTS
              value: "-Djava.security.egd=file:/dev/./urandom -XX:+UseG1GC -XX:MinRAMPercentage=60.0 -XX:InitiatingHeapOccupancyPercent=70 -XX:MaxRAMPercentage=90.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
          # AMQP settings
            - name: REPORTING_QUEUES_COUNT
              value: "10"
            - name: REPORTING_PARKINGLOT_TTL_DAYS
              value: "7"
            - name: REPORTING_CONSUMER_PREFETCHCOUNT
              value: "10"
            - name: RP_AMQP_ANALYZER-VHOST
              value: "analyzer"
            - name: RP_AMQP_PASS
              value: "rabbitmqpassword"
            - name: RP_AMQP_API_ADDRESS
              value: http://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:15672/api
            - name: RP_AMQP_ADDRESSES
              value: amqp://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:5672
          # Database settings
            - name: RP_DB_HOST
              value: reportportal-test-postgresql.eep-reportportal.svc.cluster.local
            - name: RP_DB_PORT
              value: "5432"
            - name: RP_DB_NAME
              value: "reportportal"
            - name: RP_DB_USER
              value: "postgres"
            - name: RP_DB_PASS
              value: "rppassword"
        # Storage settings
            - name: DATASTORE_TYPE
              value: "minio"
        # Minio/S3 settings
            - name: DATASTORE_ENDPOINT
              value: "http://reportportal-test-minio.eep-reportportal.svc.cluster.local:9000"
            - name: DATASTORE_ACCESSKEY
              value: "rpuser"
            - name: DATASTORE_SECRETKEY
              value: "miniopassword"
            - name: DATASTORE_BUCKETPREFIX
              value: "prj-"
            - name: DATASTORE_BUCKETPOSTFIX
              value: ""
            - name: RP_INTEGRATION_SALT_PATH
              value: "keystore"
            - name: DATASTORE_DEFAULTBUCKETNAME
              value: "rp-bucket"
            - name: MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED
              value: "false"
          readinessProbe:
            httpGet:
              path: "/api/health"
              port: 8585
            initialDelaySeconds: 40
            periodSeconds: 20
            timeoutSeconds: 5
            failureThreshold: 20
          livenessProbe:
            tcpSocket:
              port: 8585
            initialDelaySeconds: 40
            periodSeconds: 20
            timeoutSeconds: 5
            failureThreshold: 10
          volumeMounts:
      securityContext:
        {}
      serviceAccountName: reportportal
      volumes:
---
# Source: reportportal/templates/service-authorization/uat-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-uat
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-uat
  template:
    metadata:
      labels:
        component: reportportal-test-uat
      annotations:
    spec:
      initContainers:
        - name: migrations-waiting-init
          image: "reportportal/k8s-wait-for:latest"
          imagePullPolicy: IfNotPresent
          args:
            - "job-wr"
            - reportportal-test-migrations
          resources:
            requests:
              cpu: 50m
              memory: 100Mi
            limits:
              cpu: 50m
              memory: 100Mi
      containers:
        - name: "uat"
          image: "reportportal/service-authorization:5.15.0"
          imagePullPolicy: "Always"
          ports:
            - containerPort: 9999
              protocol: TCP
          resources:
            requests:
              cpu: 100m
              memory: 512Mi
            limits:
              cpu: 500m
              memory: 1Gi
          env:
            - name: SERVER_SERVLET_CONTEXT_PATH
              value: "/uat"
            - name: RP_AMQP_PASS
              value: "rabbitmqpassword"
            - name: RP_AMQP_ADDRESSES
              value: 'amqp://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:5672'
            - name: RP_INITIAL_ADMIN_PASSWORD
              value: "testpassword123"
            - name: RP_SAML_SESSION-LIVE
              value: "4320"
            - name: JAVA_OPTS
              value: "-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0 --add-opens=java.base/java.lang=ALL-UNNAMED"
            - name: RP_SESSION_LIVE
              value: "86400"
            - name: RP_DB_HOST
              value: reportportal-test-postgresql.eep-reportportal.svc.cluster.local
            - name: RP_DB_PORT
              value: "5432"
            - name: RP_DB_NAME
              value: "reportportal"
            - name: RP_DB_USER
              value: "postgres"
            - name: RP_DB_PASS
              value: "rppassword"
        # Datastore settings
            - name: DATASTORE_TYPE
              value: "minio"
        # Minio/S3 settings
            - name: DATASTORE_ENDPOINT
              value: "http://reportportal-test-minio.eep-reportportal.svc.cluster.local:9000"
            - name: DATASTORE_ACCESSKEY
              value: "rpuser"
            - name: DATASTORE_SECRETKEY
              value: "miniopassword"
            - name: DATASTORE_BUCKETPREFIX
              value: "prj-"
            - name: DATASTORE_BUCKETPOSTFIX
              value: ""
            - name: RP_INTEGRATION_SALT_PATH
              value: "keystore"
            - name: DATASTORE_DEFAULTBUCKETNAME
              value: "rp-bucket"
          readinessProbe:
            httpGet:
              path: "/uat/health"
              port: 9999
            initialDelaySeconds: 60
            periodSeconds: 40
            timeoutSeconds: 5
            failureThreshold: 10
          livenessProbe:
            tcpSocket:
              port: 9999
            initialDelaySeconds: 60
            periodSeconds: 40
            timeoutSeconds: 5
            failureThreshold: 10
          volumeMounts:
      securityContext:
        {}
      serviceAccountName: reportportal
      volumes:
---
# Source: reportportal/templates/service-index/index-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-index
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-index
  template:
    metadata:
      labels:
        component: reportportal-test-index
      annotations:
    spec:
      initContainers:
      serviceAccountName: reportportal
      containers:
      - name: index
        image: "reportportal/service-index:5.15.0"
        imagePullPolicy: "Always"
        env:
        - name: K8S_MODE
          value: "true"
        - name: RESOURCE_PATH
          value:
        ports:
        - containerPort: 8080
          protocol: TCP
        readinessProbe:
          httpGet:
            path: "/health"
            port: 8080
          initialDelaySeconds: 30
          periodSeconds: 10
          timeoutSeconds: 5
          failureThreshold: 3
          successThreshold: 1
        livenessProbe:
          tcpSocket:
            port: 8080
          initialDelaySeconds: 60
          periodSeconds: 30
          timeoutSeconds: 5
          failureThreshold: 3
        resources:
          requests:
            cpu: 150m
            memory: 128Mi
          limits:
            cpu: 200m
            memory: 256Mi
      securityContext:
        {}
---
# Source: reportportal/templates/service-jobs/jobs-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-jobs
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-jobs
  template:
    metadata:
      labels:
        component: reportportal-test-jobs
      annotations:
    spec:
      initContainers:
      - name: migrations-waiting-init
        image: "reportportal/k8s-wait-for:latest"
        imagePullPolicy: IfNotPresent
        args:
          - "job-wr"
          - reportportal-test-migrations
        resources:
          requests:
            cpu: 50m
            memory: 100Mi
          limits:
            cpu: 50m
            memory: 100Mi
      containers:
      - name: "jobs"
        image: "reportportal/service-jobs:5.15.0"
        imagePullPolicy: "Always"
        ports:
        - containerPort: 8686
          protocol: TCP
        resources:
          requests:
            cpu: 100m
            memory: 248Mi
          limits:
            cpu: 250m
            memory: 512Mi
        env:
        - name: SERVER_SERVLET_CONTEXT_PATH
          value: "/jobs"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_ATTACHMENT_CRON
          value: "0 0 */24 * * *"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_LOG_CRON
          value: "0 0 */24 * * *"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_LAUNCH_CRON
          value: "0 0 */24 * * *"
        - name: RP_ENVIRONMENT_VARIABLE_BATCH-SIZE
          value: "10000"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_STORAGE_CRON
          value: "0 0 */24 * * *"
        - name: RP_ENVIRONMENT_VARIABLE_STORAGE_PROJECT_CRON
          value: "0 */5 * * * *"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_EVENTS_RETENTIONPERIOD
          value: "365"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_EVENTS_CRON
          value: "0 0 */24 * * *"
        - name: RP_ENVIRONMENT_VARIABLE_CLEAN_STORAGE_CHUNKSIZE
          value: "200000"
        - name: JAVA_OPTS
          value: "-Djava.security.egd=file:/dev/./urandom -XX:+UseG1GC -XX:+UseStringDeduplication -XX:G1ReservePercent=20 -XX:InitiatingHeapOccupancyPercent=60 -XX:MaxRAMPercentage=70.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
        # AMQP Settings
        - name: RP_AMQP_ANALYZER-VHOST
          value: "analyzer"
        - name: RP_AMQP_PASS
          value: "rabbitmqpassword"
        - name: RP_AMQP_API_ADDRESS
          value: http://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:15672/api
        - name: RP_AMQP_ADDRESSES
          value: 'amqp://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:5672'
        # Database settings
        - name: RP_DB_HOST
          value: reportportal-test-postgresql.eep-reportportal.svc.cluster.local
        - name: RP_DB_PORT
          value: "5432"
        - name: RP_DB_NAME
          value: "reportportal"
        - name: RP_DB_USER
          value: "postgres"
        - name: RP_DB_PASS
          value: "rppassword"
        # Storage settings
        - name: DATASTORE_TYPE
          value: "minio"
        - name: DATASTORE_ENDPOINT
          value: "http://reportportal-test-minio.eep-reportportal.svc.cluster.local:9000"
        - name: DATASTORE_ACCESSKEY
          value: "rpuser"
        - name: DATASTORE_SECRETKEY
          value: "miniopassword"
        - name: DATASTORE_BUCKETPREFIX
          value: "prj-"
        - name: DATASTORE_BUCKETPOSTFIX
          value: ""
        - name: RP_INTEGRATION_SALT_PATH
          value: "keystore"
        - name: DATASTORE_DEFAULTBUCKETNAME
          value: "rp-bucket"
        - name: RP_AMQP_MAXLOGCONSUMER
          value: "1"
        readinessProbe:
          httpGet:
            path: "/jobs/health"
            port: 8686
          initialDelaySeconds: 60
          periodSeconds: 40
          timeoutSeconds: 5
          failureThreshold: 10
        livenessProbe:
          tcpSocket:
            port: 8686
          initialDelaySeconds: 60
          periodSeconds: 40
          timeoutSeconds: 5
          failureThreshold: 10
        volumeMounts:
      securityContext:
        {}
      serviceAccountName: reportportal
      volumes:
---
# Source: reportportal/templates/service-ui/ui-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: reportportal-test-ui
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-ui
  template:
    metadata:
      labels:
        component: reportportal-test-ui
      annotations:
    spec:
      initContainers:
      containers:
      - name: ui
        image: "reportportal/service-ui:5.15.0"
        imagePullPolicy: "Always"
        env:
        - name: RP_SERVER_PORT
          value: "8080"
        ports:
        - containerPort: 8080
          protocol: TCP
        resources:
          requests:
            cpu: 100m
            memory: 64Mi
          limits:
            cpu: 200m
            memory: 128Mi
        readinessProbe:
          httpGet:
            path: "/ui/health"
            port: 8080
          initialDelaySeconds: 30
          periodSeconds: 10
          timeoutSeconds: 5
          failureThreshold: 3
          successThreshold: 1
        livenessProbe:
          tcpSocket:
            port: 8080
          initialDelaySeconds: 60
          periodSeconds: 30
          timeoutSeconds: 5
          failureThreshold: 3
        volumeMounts:
      volumes:
      securityContext:
        {}
      serviceAccountName: reportportal
---
# Source: reportportal/charts/opensearch/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: opensearch-cluster-master
  labels:
    helm.sh/chart: opensearch-2.36.0
    app.kubernetes.io/name: opensearch
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "2.19.4"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: opensearch-cluster-master
  annotations:
    majorVersion: "2"
spec:
  serviceName: opensearch-cluster-master-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: opensearch
      app.kubernetes.io/instance: reportportal-test
  replicas: 1
  podManagementPolicy: Parallel
  updateStrategy:
    type: RollingUpdate
  volumeClaimTemplates:
  - metadata:
      name: opensearch-cluster-master
    spec:
      accessModes:
      - "ReadWriteOnce"
      resources:
        requests:
          storage: "8Gi"
  template:
    metadata:
      name: "opensearch-cluster-master"
      labels:
        helm.sh/chart: opensearch-2.36.0
        app.kubernetes.io/name: opensearch
        app.kubernetes.io/instance: reportportal-test
        app.kubernetes.io/version: "2.19.4"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: opensearch-cluster-master
      annotations:
        configchecksum: 489c005c0202a29844c2d245d092e76cc576db525cc618371deaf7a0c14d0ca
    spec:
      securityContext:
        fsGroup: 1000
        runAsUser: 1000
      automountServiceAccountToken: false
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 1
            podAffinityTerm:
              topologyKey: kubernetes.io/hostname
              labelSelector:
                matchExpressions:
                - key: app.kubernetes.io/instance
                  operator: In
                  values:
                  - reportportal-test
                - key: app.kubernetes.io/name
                  operator: In
                  values:
                  - opensearch
      terminationGracePeriodSeconds: 120
      volumes:
      - name: config
        configMap:
          name: opensearch-cluster-master-config
      - emptyDir: {}
        name: config-emptydir
      enableServiceLinks: true
      initContainers:
      - name: fsgroup-volume
        image: "busybox:latest"
        imagePullPolicy: "IfNotPresent"
        command: ['sh', '-c']
        args:
          - 'chown -R 1000:1000 /usr/share/opensearch/data'
        securityContext:
          runAsUser: 0
        resources:
          {}
        volumeMounts:
          - name: "opensearch-cluster-master"
            mountPath: /usr/share/opensearch/data
      - name: configfile
        image: "opensearchproject/opensearch:2.19.4"
        imagePullPolicy: "IfNotPresent"
        command:
        - sh
        - -c
        - |
          #!/usr/bin/env bash
          cp -r /tmp/configfolder/*  /tmp/config/
        securityContext:
          capabilities:
            drop:
            - ALL
          runAsNonRoot: true
          runAsUser: 1000
        resources:
          {}
        volumeMounts:
          - mountPath: /tmp/config/
            name: config-emptydir
          - name: config
            mountPath: /tmp/configfolder/opensearch.yml
            subPath: opensearch.yml
      containers:
      - name: "opensearch"
        securityContext:
          capabilities:
            drop:
            - ALL
          runAsNonRoot: true
          runAsUser: 1000

        image: "opensearchproject/opensearch:2.19.4"
        imagePullPolicy: "IfNotPresent"
        readinessProbe:
          failureThreshold: 3
          periodSeconds: 5
          tcpSocket:
            port: 9200
          timeoutSeconds: 3
        startupProbe:
          failureThreshold: 30
          initialDelaySeconds: 30
          periodSeconds: 10
          tcpSocket:
            port: 9200
          timeoutSeconds: 3
        ports:
        - name: http
          containerPort: 9200
        - name: transport
          containerPort: 9300
        - name: metrics
          containerPort: 9600
        resources:
          requests:
            cpu: 1000m
            memory: 100Mi
        env:
        - name: node.name
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        - name: discovery.seed_hosts
          value: "opensearch-cluster-master-headless"
        - name: cluster.name
          value: "opensearch-cluster"
        - name: network.host
          value: "0.0.0.0"
        - name: OPENSEARCH_JAVA_OPTS
          value: "-Xmx512M -Xms512M"
        - name: node.roles
          value: "master,ingest,data,remote_cluster_client,"
        - name: discovery.type
          value: "single-node"
        - name: DISABLE_INSTALL_DEMO_CONFIG
          value: "true"
        - name: DISABLE_SECURITY_PLUGIN
          value: "true"
        volumeMounts:
        - name: "opensearch-cluster-master"
          mountPath: /usr/share/opensearch/data
        - name: config-emptydir
          mountPath: /usr/share/opensearch/config/opensearch.yml
          subPath: opensearch.yml
---
# Source: reportportal/charts/postgresql/templates/primary/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: reportportal-test-postgresql
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.5.0
    helm.sh/chart: postgresql-16.7.21
    app.kubernetes.io/component: primary
spec:
  replicas: 1
  serviceName: reportportal-test-postgresql-hl
  updateStrategy:
    rollingUpdate: {}
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: postgresql
      app.kubernetes.io/component: primary
  template:
    metadata:
      name: reportportal-test-postgresql
      labels:
        app.kubernetes.io/instance: reportportal-test
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: postgresql
        app.kubernetes.io/version: 17.5.0
        helm.sh/chart: postgresql-16.7.21
        app.kubernetes.io/component: primary
    spec:
      serviceAccountName: reportportal-test-postgresql

      automountServiceAccountToken: false
      affinity:
        podAffinity:

        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app.kubernetes.io/instance: reportportal-test
                    app.kubernetes.io/name: postgresql
                    app.kubernetes.io/component: primary
                topologyKey: kubernetes.io/hostname
              weight: 1
        nodeAffinity:

      securityContext:
        fsGroup: 1001
        fsGroupChangePolicy: Always
        supplementalGroups: []
        sysctls: []
      hostNetwork: false
      hostIPC: false
      containers:
        - name: postgresql
          image: docker.io/bitnamilegacy/postgresql:17.5.0-debian-12-r20
          imagePullPolicy: "IfNotPresent"
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsGroup: 1001
            runAsNonRoot: true
            runAsUser: 1001
            seLinuxOptions: {}
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: BITNAMI_DEBUG
              value: "false"
            - name: POSTGRESQL_PORT_NUMBER
              value: "5432"
            - name: POSTGRESQL_VOLUME_DIR
              value: "/bitnami/postgresql"
            - name: PGDATA
              value: "/bitnami/postgresql/data"
            # Authentication
            - name: POSTGRES_PASSWORD_FILE
              value: /opt/bitnami/postgresql/secrets/postgres-password
            - name: POSTGRES_DATABASE
              value: "reportportal"
            # LDAP
            - name: POSTGRESQL_ENABLE_LDAP
              value: "no"
            # TLS
            - name: POSTGRESQL_ENABLE_TLS
              value: "no"
            # Audit
            - name: POSTGRESQL_LOG_HOSTNAME
              value: "false"
            - name: POSTGRESQL_LOG_CONNECTIONS
              value: "false"
            - name: POSTGRESQL_LOG_DISCONNECTIONS
              value: "false"
            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
              value: "off"
            # Others
            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
              value: "error"
            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
              value: "pgaudit"
          ports:
            - name: tcp-postgresql
              containerPort: 5432
          livenessProbe:
            failureThreshold: 6
            initialDelaySeconds: 30
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
            exec:
              command:
                - /bin/sh
                - -c
                - exec pg_isready -U "postgres" -d "dbname=reportportal" -h 127.0.0.1 -p 5432
          readinessProbe:
            failureThreshold: 6
            initialDelaySeconds: 5
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
            exec:
              command:
                - /bin/sh
                - -c
                - -e
                - |
                  exec pg_isready -U "postgres" -d "dbname=reportportal" -h 127.0.0.1 -p 5432
          resources:
            limits:
              cpu: 150m
              ephemeral-storage: 2Gi
              memory: 192Mi
            requests:
              cpu: 100m
              ephemeral-storage: 50Mi
              memory: 128Mi
          volumeMounts:
            - name: empty-dir
              mountPath: /tmp
              subPath: tmp-dir
            - name: empty-dir
              mountPath: /opt/bitnami/postgresql/conf
              subPath: app-conf-dir
            - name: empty-dir
              mountPath: /opt/bitnami/postgresql/tmp
              subPath: app-tmp-dir
            - name: postgresql-password
              mountPath: /opt/bitnami/postgresql/secrets/
            - name: dshm
              mountPath: /dev/shm
            - name: data
              mountPath: /bitnami/postgresql
      volumes:
        - name: empty-dir
          emptyDir: {}
        - name: postgresql-password
          secret:
            secretName: reportportal-test-postgresql
        - name: dshm
          emptyDir:
            medium: Memory
  volumeClaimTemplates:
    - apiVersion: v1
      kind: PersistentVolumeClaim
      metadata:
        name: data
      spec:
        accessModes:
          - "ReadWriteOnce"
        resources:
          requests:
            storage: "8Gi"
---
# Source: reportportal/charts/rabbitmq/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: reportportal-test-rabbitmq
  namespace: "eep-reportportal"
  labels:
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: rabbitmq
    app.kubernetes.io/version: 4.1.2
    helm.sh/chart: rabbitmq-16.0.11
spec:
  serviceName: reportportal-test-rabbitmq-headless
  podManagementPolicy: OrderedReady
  replicas: 1
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/instance: reportportal-test
      app.kubernetes.io/name: rabbitmq
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: reportportal-test
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: rabbitmq
        app.kubernetes.io/version: 4.1.2
        helm.sh/chart: rabbitmq-16.0.11
      annotations:
        checksum/config: 98524157265f953be9e946b8b194231674bf7fe7f0188dee9d92fcb9f552a278
        checksum/secret: d53bea273f66a46bac7e317c8412bc2cdc4c40c8f6d7f50583398e2dd44277d1
    spec:

      serviceAccountName: reportportal-test-rabbitmq
      affinity:
        podAffinity:

        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app.kubernetes.io/instance: reportportal-test
                    app.kubernetes.io/name: rabbitmq
                topologyKey: kubernetes.io/hostname
              weight: 1
        nodeAffinity:

      automountServiceAccountToken: true
      securityContext:
        fsGroup: 1001
        fsGroupChangePolicy: Always
        supplementalGroups: []
        sysctls: []
      terminationGracePeriodSeconds: 120
      enableServiceLinks: true
      initContainers:
        - name: prepare-plugins-dir
          image: docker.io/bitnamilegacy/rabbitmq:4.1.2-debian-12-r1
          imagePullPolicy: "IfNotPresent"
          resources:
            limits:
              cpu: 375m
              ephemeral-storage: 2Gi
              memory: 384Mi
            requests:
              cpu: 250m
              ephemeral-storage: 50Mi
              memory: 256Mi
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsGroup: 1001
            runAsNonRoot: true
            runAsUser: 1001
            seLinuxOptions: {}
            seccompProfile:
              type: RuntimeDefault
          command:
            - /bin/bash
          args:
            - -ec
            - |
              #!/bin/bash

              . /opt/bitnami/scripts/liblog.sh

              info "Copying plugins dir to empty dir"
              # In order to not break the possibility of installing custom plugins, we need
              # to make the plugins directory writable, so we need to copy it to an empty dir volume
              cp -r --preserve=mode /opt/bitnami/rabbitmq/plugins/ /emptydir/app-plugins-dir
          volumeMounts:
            - name: empty-dir
              mountPath: /emptydir
      containers:
        - name: rabbitmq
          image: docker.io/bitnamilegacy/rabbitmq:4.1.2-debian-12-r1
          imagePullPolicy: "IfNotPresent"
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsGroup: 1001
            runAsNonRoot: true
            runAsUser: 1001
            seLinuxOptions: {}
            seccompProfile:
              type: RuntimeDefault
          lifecycle:
            preStop:
              exec:
                command:
                  - /bin/bash
                  - -ec
                  - |
                    if [[ -f /opt/bitnami/scripts/rabbitmq/nodeshutdown.sh ]]; then
                        /opt/bitnami/scripts/rabbitmq/nodeshutdown.sh -t "120" -d "false"
                    else
                        rabbitmqctl stop_app
                    fi
          env:
            - name: BITNAMI_DEBUG
              value: "false"
            - name: MY_POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
            - name: MY_POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: MY_POD_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: RABBITMQ_FORCE_BOOT
              value: "no"
            - name: RABBITMQ_NODE_NAME
              value: "rabbit@$(MY_POD_NAME).reportportal-test-rabbitmq-headless.$(MY_POD_NAMESPACE).svc.cluster.local"
            - name: RABBITMQ_UPDATE_PASSWORD
              value: "no"
            - name: RABBITMQ_MNESIA_DIR
              value: "/opt/bitnami/rabbitmq/.rabbitmq/mnesia/$(RABBITMQ_NODE_NAME)"
            - name: RABBITMQ_LDAP_ENABLE
              value: "no"
            - name: RABBITMQ_LOGS
              value: "-"
            - name: RABBITMQ_ULIMIT_NOFILES
              value: "65535"
            - name: RABBITMQ_USE_LONGNAME
              value: "true"
            - name: RABBITMQ_ERL_COOKIE_FILE
              value: /opt/bitnami/rabbitmq/secrets/rabbitmq-erlang-cookie
            - name: RABBITMQ_LOAD_DEFINITIONS
              value: "no"
            - name: RABBITMQ_DEFINITIONS_FILE
              value: "/app/load_definition.json"
            - name: RABBITMQ_SECURE_PASSWORD
              value: "yes"
            - name: RABBITMQ_USERNAME
              value: "rabbitmq"
            - name: RABBITMQ_PASSWORD_FILE
              value: /opt/bitnami/rabbitmq/secrets/rabbitmq-password
            - name: RABBITMQ_PLUGINS
              value: "rabbitmq_management, rabbitmq_peer_discovery_k8s, rabbitmq_auth_backend_ldap, rabbitmq_consistent_hash_exchange, rabbitmq_shovel, rabbitmq_shovel_management\n"
          envFrom:
          ports:
            - name: amqp
              containerPort: 5672
            - name: dist
              containerPort: 25672
            - name: stats
              containerPort: 15672
            - name: epmd
              containerPort: 4369
            - name: metrics
              containerPort: 9419
          livenessProbe:
            failureThreshold: 6
            initialDelaySeconds: 120
            periodSeconds: 30
            successThreshold: 1
            timeoutSeconds: 20
            exec:
              command:
                - /bin/bash
                - -ec
                - curl -f --user rabbitmq:$(< $RABBITMQ_PASSWORD_FILE) 127.0.0.1:15672/api/health/checks/virtual-hosts
          readinessProbe:
            failureThreshold: 3
            initialDelaySeconds: 10
            periodSeconds: 30
            successThreshold: 1
            timeoutSeconds: 20
            exec:
              command:
                - /bin/bash
                - -ec
                - curl -f --user rabbitmq:$(< $RABBITMQ_PASSWORD_FILE) 127.0.0.1:15672/api/health/checks/local-alarms
          resources:
            limits:
              cpu: 375m
              ephemeral-storage: 2Gi
              memory: 384Mi
            requests:
              cpu: 250m
              ephemeral-storage: 50Mi
              memory: 256Mi
          volumeMounts:
            - name: configuration
              mountPath: /bitnami/rabbitmq/conf
            - name: empty-dir
              mountPath: /tmp
              subPath: tmp-dir
            - name: empty-dir
              mountPath: /opt/bitnami/rabbitmq/etc/rabbitmq
              subPath: app-conf-dir
            - name: empty-dir
              mountPath: /opt/bitnami/rabbitmq/var/lib/rabbitmq
              subPath: app-tmp-dir
            - name: empty-dir
              mountPath: /opt/bitnami/rabbitmq/.rabbitmq/
              subPath: app-erlang-cookie
            - name: empty-dir
              mountPath: /opt/bitnami/rabbitmq/var/log/rabbitmq
              subPath: app-logs-dir
            - name: empty-dir
              mountPath: /opt/bitnami/rabbitmq/plugins
              subPath: app-plugins-dir
            - name: data
              mountPath: /opt/bitnami/rabbitmq/.rabbitmq/mnesia
            - name: rabbitmq-secrets
              mountPath: /opt/bitnami/rabbitmq/secrets
      volumes:
        - name: empty-dir
          emptyDir: {}
        - name: configuration
          projected:
            sources:
              - secret:
                  name: reportportal-test-rabbitmq-config
        - name: rabbitmq-secrets
          projected:
            sources:
              - secret:
                  name: reportportal-test-rabbitmq
              - secret:
                  name: reportportal-test-rabbitmq
  volumeClaimTemplates:
    - apiVersion: v1
      kind: PersistentVolumeClaim
      metadata:
        name: data
        labels:
          app.kubernetes.io/instance: reportportal-test
          app.kubernetes.io/name: rabbitmq
      spec:
        accessModes:
            - "ReadWriteOnce"
        resources:
          requests:
            storage: "8Gi"
---
# Source: reportportal/templates/service-auto-analyzer/analyzer-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: reportportal-test-analyzer
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  replicas: 1
  selector:
    matchLabels:
      component: reportportal-test-analyzer
  serviceName: reportportal-test-analyzer
  template:
    metadata:
      labels:
        component: reportportal-test-analyzer
      annotations:
    spec:
      initContainers:
      - name: migrations-waiting-init
        image: "reportportal/k8s-wait-for:latest"
        imagePullPolicy: IfNotPresent
        args:
          - "pod-wr"
          - "-lcomponent=reportportal-test-api"
        resources:
          requests:
            cpu: 50m
            memory: 100Mi
          limits:
            cpu: 50m
            memory: 100Mi
      containers:
      - name: "analyzer"
        image: "reportportal/service-auto-analyzer:5.15.0"
        imagePullPolicy: "Always"
        ports:
        - containerPort: 5001
          name: analyzercore
        resources:
          limits:
            cpu: 500m
            memory: 1Gi
          requests:
            cpu: 500m
            memory: 512Mi
        env:
        - name: DATASTORE_TYPE
          value: "minio"
        - name: DATASTORE_ENDPOINT
          value: "http://reportportal-test-minio.eep-reportportal.svc.cluster.local:9000"
        - name: DATASTORE_ACCESSKEY
          value: "rpuser"
        - name: DATASTORE_SECRETKEY
          value: "miniopassword"
        - name: DATASTORE_BUCKETPREFIX
          value: "prj-"
        - name: DATASTORE_BUCKETPOSTFIX
          value: ""
        - name: DATASTORE_DEFAULTBUCKETNAME
          value: "rp-bucket/analyzer"
        - name: RP_AMQP_PASS
          value: "rabbitmqpassword"
        - name: AMQP_URL
          value: amqp://rabbitmq:$(RP_AMQP_PASS)@reportportal-test-rabbitmq.eep-reportportal.svc.cluster.local:5672/
        - name: AMQP_EXCHANGE_NAME
          value: "analyzer-default"
        - name: AMQP_VIRTUAL_HOST
          value: "analyzer"
        - name: ES_HOSTS
          value: "http://opensearch-cluster-master.eep-reportportal.svc.cluster.local:9200"
        - name: ES_USER
          value: ""
        - name: ES_PASSWORD
          value: ""
        - name: UWSGI_WORKERS
          value: "2"
        readinessProbe:
          httpGet:
            path: /
            port: 5001
          initialDelaySeconds: 30
          periodSeconds: 10
          timeoutSeconds: 5
          failureThreshold: 3
          successThreshold: 1
        livenessProbe:
          tcpSocket:
            port: 5001
          initialDelaySeconds: 60
          periodSeconds: 30
          timeoutSeconds: 10
          failureThreshold: 3
          successThreshold: 1
        volumeMounts:
      securityContext:
        {}
      serviceAccountName: reportportal
---
# Source: reportportal/templates/service-migrations/migrations-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: reportportal-test-migrations
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
spec:
  template:
    metadata:
      labels:
        component: reportportal-test-migrations
      annotations:
    spec:
      restartPolicy: OnFailure
      containers:
      - env:
        - name: POSTGRES_SSLMODE
          value: "disable"
        - name: POSTGRES_SERVER
          value: reportportal-test-postgresql.eep-reportportal.svc.cluster.local
        - name: POSTGRES_DB
          value: "reportportal"
        - name: POSTGRES_PORT
          value: "5432"
        - name: POSTGRES_USER
          value: "postgres"
        - name: POSTGRES_PASSWORD

          value: "rppassword"

        image: "reportportal/migrations:5.15.0"
        imagePullPolicy: "Always"
        name: migrations
        resources:
          requests:
            cpu: 100m
            memory: 128Mi
          limits:
            cpu: 100m
            memory: 128Mi
      securityContext:
        {}
      serviceAccountName: reportportal
---
# Source: reportportal/templates/ingress/gateway-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: reportportal-test-gateway-ingress
  labels:
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
spec:
  ingressClassName: nginx
  # Define the TLS settings
  # Define the rules for the ingress
  rules:
  - http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: reportportal-test-index
            port:
              name: headless
      - path: /ui
        pathType: Prefix
        backend:
          service:
            name: reportportal-test-ui
            port:
              name: headless
      - path: /uat
        pathType: Prefix
        backend:
          service:
            name: reportportal-test-uat
            port:
              name: headless
      - path: /api
        pathType: Prefix
        backend:
          service:
            name: reportportal-test-api
            port:
              name: headless
status:
  loadBalancer: {}
---
# Source: reportportal/templates/volumes/pv.yaml
# This snippet creates a PersistentVolume when ReportPortal uses
# filesystem as a storage type instead of a bucket.
# If you set a type of volume to 'gcp' or 'aws' in values.yaml
# this snippet won't be used for creating a PersistentVolume.
# GCP and AWS provides dynamic provisioning of volumes.
# However, you can use a CSI type to get an access to pre-existing volumes.
---
# Source: reportportal/templates/hooks/tests/readiness-test.yaml
apiVersion: v1
kind: Pod
metadata:
  name: reportportal-test-readiness-test
  labels:


    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    "helm.sh/hook": test
spec:
  containers:
  - name: test-container
    image: "curlimages/curl:latest"
    command: ["/bin/sh", "-c"]
    args:
    - >
      for url in \
        "http://reportportal-test-index:8080/health" \
        "http://reportportal-test-ui:8080/ui/health" \
        "http://reportportal-test-api:8585/api/health" \
        "http://reportportal-test-uat:9999/uat/health" \
        "http://reportportal-test-jobs:8686/jobs/health"
      do
        echo "Checking $url";
        response=$(curl --write-out "%{http_code}" --silent --output /dev/null $url);
        if [ $response -ne 200 ]; then
          echo "Health check failed for $url with response code $response";
          exit 1;
        else
          echo "Health check succeeded for $url";
        fi;
      done;
      echo "All health checks passed.";
    resources:
      limits:
        cpu: 100m
        memory: 128Mi
      requests:
        cpu: 50m
        memory: 64Mi
  restartPolicy: Never
---
# Source: reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: reportportal-test-pre-upgrade-cleanup
  labels:

    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: reportportal-test
    app.kubernetes.io/version: "25.2.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-25.12.19
    heritage: "Helm"
    release: "reportportal-test"
    chart: reportportal-25.12.19
    app: "reportportal"
  annotations:
    "helm.sh/hook": pre-upgrade
    "helm.sh/hook-delete-policy": hook-succeeded
spec:
  template:
    metadata:
      labels:
        component: reportportal-test-pre-upgrade-cleanup
      annotations:
    spec:
      serviceAccountName: reportportal
      restartPolicy: OnFailure
      containers:
      - name: delete-job
        image: "bitnamisecure/kubectl:latest"
        command:
        - /bin/sh
        - -c
        - |
          kubectl delete job reportportal-test-migrations --ignore-not-found=true
        resources:
          limits:
            cpu: 100m
            memory: 128Mi
          requests:
            cpu: 50m
            memory: 64Mi
```

</p>
</details> 


---
### Result

  - ArgoCD deployments work correctly with proper resource ordering
  - Standard Helm deployments (without ArgoCD) are unaffected - no hook annotations added
  - Users can set global.argocd.enabled=true when deploying with ArgoCD, and RBAC resources are deployed when it is a fresh ArgoCD installation, (not just upgrades).

