### PR TITLE
Add nodeSelector parameter for hooks

### DIFF
--- a/docs/parameters-reference.md
+++ b/docs/parameters-reference.md
@@ -444,6 +444,7 @@ This document provides a comprehensive reference of all configurable parameters 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `hooks.enabled` | Enable hooks | `true` |
+| `hooks.nodeSelector` | Node selector | `{}` |
 | `hooks.preUpgrade.enabled` | Enable pre-upgrade hook | `true` |
 | `hooks.preUpgrade.resources.requests.cpu` | Pre-upgrade CPU requests | `50m` |
 | `hooks.preUpgrade.resources.requests.memory` | Pre-upgrade memory requests | `64Mi` |

--- a/reportportal/templates/hooks/tests/readiness-test.yaml
+++ b/reportportal/templates/hooks/tests/readiness-test.yaml
@@ -33,6 +33,12 @@ spec:
       echo "All health checks passed.";
     resources:
       {{- toYaml .Values.hooks.test.resources | nindent 6 }}
+  {{- if .Values.hooks.nodeSelector }}
+  nodeSelector:
+    {{- range $key, $value := .Values.hooks.nodeSelector }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   restartPolicy: Never
   {{- with .Values.global.tolerations }}
   tolerations:

--- a/reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
+++ b/reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
@@ -36,6 +36,12 @@ spec:
           kubectl delete job {{ include "reportportal.fullname" . }}-migrations --ignore-not-found=true
         resources:
           {{- toYaml .Values.hooks.preUpgrade.resources | nindent 10 }}
+      {{- if .Values.hooks.nodeSelector }}
+      nodeSelector:
+        {{- range $key, $value := .Values.hooks.nodeSelector }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.global.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -1197,6 +1197,13 @@ k8s:
 ## @param hooks Helm 3+ hooks toggles
 hooks:
   enabled: true
+  ## @param hooks.nodeSelector define which Nodes the Pods are scheduled on.
+  ## You can choose compute classes for GKE Autopilot Pods https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-compute-classes
+  ## Use cloud.google.com/compute-class: "COMPUTE_CLASS" for specific GKE Autopilot compute class.
+  ## Use kubernetes.io/arch: "ARCHITECTURE" for specific GKE Autopilot CPU architecture.
+  ## Use disktype: "ssd" for specific disk type.
+  ##
+  nodeSelector: {}
   preUpgrade:
     enabled: true
     resources:


### PR DESCRIPTION
## Motivation

In multi-OS clusters there is no possibility to pin the test and pre-upgrade hooks to the Linux nodes. Having the parameter override for nodeSelector aligns with the configuration for the other services and jobs defined in the project.

## Alternatives considered
Considered to duplicate the parameter per hook. Decided it is not needed in the motivational use case (so the hooks could be placed on different nodes), so proceeded to define the parameter on the `hooks/` level.

## Testing

### Hooks with provided `nodeSelector`
<details>
<summary> Readiness test </summary>

```yaml
# Source: reportportal/templates/hooks/tests/readiness-test.yaml
apiVersion: v1
kind: Pod
metadata:
  name: testing-instance-readiness-test
  labels:
    
    
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: testing-instance
    app.kubernetes.io/version: "26.0.1"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-26.2.6
    heritage: "Helm"
    release: "testing-instance"
    chart: reportportal-26.2.6
    app: "reportportal"
  annotations:
    "helm.sh/hook": test
spec:
  containers:
  - name: test-container
    image: "curlimages/curl:latest"
    command: ["/bin/sh", "-c"]
    args:
    - >
      for url in \
        "http://testing-instance-reportportal-index:8080/health" \
        "http://testing-instance-reportportal-ui:8080/ui/health" \
        "http://testing-instance-reportportal-api:8585/api/health" \
        "http://testing-instance-reportportal-uat:9999/uat/health" \
        "http://testing-instance-reportportal-jobs:8686/jobs/health"
      do
        echo "Checking $url";
        response=$(curl --write-out "%{http_code}" --silent --output /dev/null $url);
        if [ $response -ne 200 ]; then
          echo "Health check failed for $url with response code $response";
          exit 1;
        else
          echo "Health check succeeded for $url";
        fi;
      done;
      echo "All health checks passed.";
    resources:
      limits:
        cpu: 100m
        memory: 128Mi
      requests:
        cpu: 50m
        memory: 64Mi
  nodeSelector:
    kubernetes.io/os: "linux"
  restartPolicy: Never
```
</details>

<details>
<summary> Pre-upgrade cleanup </summary>

```yaml
---
# Source: reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: testing-instance-reportportal-pre-upgrade-cleanup
  labels:
        
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: testing-instance
    app.kubernetes.io/version: "26.0.1"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-26.2.6
    heritage: "Helm"
    release: "testing-instance"
    chart: reportportal-26.2.6
    app: "reportportal"
  annotations:
    "helm.sh/hook": pre-upgrade
    "helm.sh/hook-delete-policy": hook-succeeded
spec:
  template:
    metadata:
      labels:
        component: testing-instance-reportportal-pre-upgrade-cleanup
      annotations:
    spec:
      serviceAccountName: reportportal
      restartPolicy: OnFailure
      containers:
      - name: delete-job
        image: "bitnamisecure/kubectl:latest"
        command:
        - /bin/sh
        - -c
        - |
          kubectl delete job testing-instance-reportportal-migrations --ignore-not-found=true
        resources:
          limits:
            cpu: 100m
            memory: 128Mi
          requests:
            cpu: 50m
            memory: 64Mi
      nodeSelector:
        kubernetes.io/os: "linux"
```
</details>

### Default `values.yaml`

<details>

<summary>Readiness test</summary>

```yaml
---
# Source: reportportal/templates/hooks/tests/readiness-test.yaml
apiVersion: v1
kind: Pod
metadata:
  name: testing-instance-readiness-test
  labels:
    
    
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: testing-instance
    app.kubernetes.io/version: "26.0.1"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-26.2.6
    heritage: "Helm"
    release: "testing-instance"
    chart: reportportal-26.2.6
    app: "reportportal"
  annotations:
    "helm.sh/hook": test
spec:
  containers:
  - name: test-container
    image: "curlimages/curl:latest"
    command: ["/bin/sh", "-c"]
    args:
    - >
      for url in \
        "http://testing-instance-reportportal-index:8080/health" \
        "http://testing-instance-reportportal-ui:8080/ui/health" \
        "http://testing-instance-reportportal-api:8585/api/health" \
        "http://testing-instance-reportportal-uat:9999/uat/health" \
        "http://testing-instance-reportportal-jobs:8686/jobs/health"
      do
        echo "Checking $url";
        response=$(curl --write-out "%{http_code}" --silent --output /dev/null $url);
        if [ $response -ne 200 ]; then
          echo "Health check failed for $url with response code $response";
          exit 1;
        else
          echo "Health check succeeded for $url";
        fi;
      done;
      echo "All health checks passed.";
    resources:
      limits:
        cpu: 100m
        memory: 128Mi
      requests:
        cpu: 50m
        memory: 64Mi
  restartPolicy: Never
```

</details>

<details>

<summary>Pre-upgrade cleanup</summary>

```yaml
---
# Source: reportportal/templates/hooks/upgrade/pre-upgrade-cleanup.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: testing-instance-reportportal-pre-upgrade-cleanup
  labels:
        
    app.kubernetes.io/name: reportportal
    app.kubernetes.io/instance: testing-instance
    app.kubernetes.io/version: "26.0.1"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: reportportal-26.2.6
    heritage: "Helm"
    release: "testing-instance"
    chart: reportportal-26.2.6
    app: "reportportal"
  annotations:
    "helm.sh/hook": pre-upgrade
    "helm.sh/hook-delete-policy": hook-succeeded
spec:
  template:
    metadata:
      labels:
        component: testing-instance-reportportal-pre-upgrade-cleanup
      annotations:
    spec:
      serviceAccountName: reportportal
      restartPolicy: OnFailure
      containers:
      - name: delete-job
        image: "bitnamisecure/kubectl:latest"
        command:
        - /bin/sh
        - -c
        - |
          kubectl delete job testing-instance-reportportal-migrations --ignore-not-found=true
        resources:
          limits:
            cpu: 100m
            memory: 128Mi
          requests:
            cpu: 50m
            memory: 64Mi
```

</details>

