### PR TITLE
Add global.clusterDomain value

### DIFF
--- a/docs/parameters-reference.md
+++ b/docs/parameters-reference.md
@@ -8,6 +8,7 @@ This document provides a comprehensive reference of all configurable parameters 
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `global.clusterDomain` | Kubernetes cluster domain used to build service FQDNs | `cluster.local` |
 | `global.imageRegistry` | Global image registry | `""` |
 | `global.imagePullSecrets` | Global registry secret names as an array | `[]` |
 | `global.nameOverride` | Expand the name of the chart | `""` |

--- a/reportportal/templates/_helpers.tpl
+++ b/reportportal/templates/_helpers.tpl
@@ -124,11 +124,11 @@ Override storage.endpoint to point at an external or custom service.
 {{- $scheme := ternary "https" "http" .Values.storage.ssl -}}
 {{- if eq $storageType "minio" -}}
   {{- $port := .Values.storage.port | default 9000 -}}
-  {{- $host := .Values.storage.endpoint | default (printf "%s-minio.%s.svc.cluster.local" .Release.Name .Release.Namespace) -}}
+  {{- $host := .Values.storage.endpoint | default (printf "%s-minio.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) -}}
   {{- printf "%s://%s:%v" $scheme $host $port -}}
 {{- else if eq $storageType "seaweedfs" -}}
   {{- $port := .Values.storage.port | default 8333 -}}
-  {{- $host := .Values.storage.endpoint | default (printf "%s-seaweedfs-all-in-one.%s.svc.cluster.local" .Release.Name .Release.Namespace) -}}
+  {{- $host := .Values.storage.endpoint | default (printf "%s-seaweedfs-all-in-one.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) -}}
   {{- printf "%s://%s:%v" $scheme $host $port -}}
 {{- end -}}
 {{- end -}}

--- a/reportportal/templates/service-api/api-deployment.yaml
+++ b/reportportal/templates/service-api/api-deployment.yaml
@@ -78,7 +78,7 @@ spec:
             - name: COM_TA_REPORTPORTAL_JOB_LOAD_PLUGINS_CRON
               value: "{{ .Values.serviceapi.cronJobs.loadPlugins }}"
             - name: RP_JOBS_BASEURL
-              value: {{ ternary "https" "http" .Values.k8s.networking.ssl }}://{{ include "reportportal.fullname" . }}-jobs{{ printf ".%s.svc.cluster.local" .Release.Namespace }}:8686/jobs
+              value: {{ ternary "https" "http" .Values.k8s.networking.ssl }}://{{ include "reportportal.fullname" . }}-jobs{{ printf ".%s.svc.%s" .Release.Namespace .Values.global.clusterDomain }}:8686/jobs
             - name: COM_TA_REPORTPORTAL_JOB_INTERRUPT_BROKEN_LAUNCHES_CRON
               value: "{{ .Values.serviceapi.cronJobs.interruptBrockenLaunches }}"
             - name: RP_ENVIRONMENT_VARIABLE_PATTERN-ANALYSIS_BATCH-SIZE
@@ -120,12 +120,12 @@ spec:
               value: "{{ .Values.msgbroker.password }}"
           {{- end }}
             - name: RP_AMQP_API_ADDRESS
-              value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.apiport }}/api
+              value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) }}:{{ .Values.msgbroker.apiport }}/api
             - name: RP_AMQP_ADDRESSES
-              value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}
+              value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) }}:{{ .Values.msgbroker.port }}
           # Database settings
             - name: RP_DB_HOST
-              value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+              value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) }}
             - name: RP_DB_PORT
               value: "{{ .Values.database.port }}"
             - name: RP_DB_NAME

--- a/reportportal/templates/service-authorization/uat-deployment.yaml
+++ b/reportportal/templates/service-authorization/uat-deployment.yaml
@@ -91,7 +91,7 @@ spec:
               value: "{{ .Values.msgbroker.password }}"
           {{- end }}
             - name: RP_AMQP_ADDRESSES
-              value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}'
+              value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) }}:{{ .Values.msgbroker.port }}'
           {{- if .Values.uat.superadminInitPasswd.secretName }}
             - name: RP_INITIAL_ADMIN_PASSWORD
               valueFrom:
@@ -111,7 +111,7 @@ spec:
             - name: RP_SESSION_LIVE
               value: "{{ .Values.uat.sessionLiveTime }}"
             - name: RP_DB_HOST
-              value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+              value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) }}
             - name: RP_DB_PORT
               value: "{{ .Values.database.port }}"
             - name: RP_DB_NAME

--- a/reportportal/templates/service-auto-analyzer/analyzer-statefulset.yaml
+++ b/reportportal/templates/service-auto-analyzer/analyzer-statefulset.yaml
@@ -118,13 +118,13 @@ spec:
           value: "{{ .Values.msgbroker.password }}"
         {{- end }}
         - name: AMQP_URL
-          value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}/
+          value: {{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) }}:{{ .Values.msgbroker.port }}/
         - name: AMQP_EXCHANGE_NAME
           value: "{{ .Values.msgbroker.analyzerExchangeName | default "analyzer-default" }}"
         - name: AMQP_VIRTUAL_HOST
           value: "{{ .Values.msgbroker.vhost }}"
         - name: ES_HOSTS
-          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.cluster.local" .Release.Namespace) }}:{{ .Values.searchengine.port }}"
+          value: "{{ ternary "https" "http" .Values.searchengine.ssl }}://{{ .Values.searchengine.endpoint | default (printf "opensearch-cluster-master.%s.svc.%s" .Release.Namespace .Values.global.clusterDomain) }}:{{ .Values.searchengine.port }}"
         {{- if .Values.searchengine.secretName }}
         - name: ES_USER
           valueFrom:

--- a/reportportal/templates/service-jobs/jobs-deployment.yaml
+++ b/reportportal/templates/service-jobs/jobs-deployment.yaml
@@ -104,12 +104,12 @@ spec:
           value: "{{ .Values.msgbroker.password }}"
         {{- end }}
         - name: RP_AMQP_API_ADDRESS
-          value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.apiport }}/api
+          value: {{ ternary "https" "http" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.apiuser }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) }}:{{ .Values.msgbroker.apiport }}/api
         - name: RP_AMQP_ADDRESSES
-          value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.msgbroker.port }}'
+          value: '{{ ternary "amqps" "amqp" .Values.msgbroker.ssl }}://{{ .Values.msgbroker.user }}:$(RP_AMQP_PASS)@{{ .Values.msgbroker.endpoint | default (printf "%s-rabbitmq.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) }}:{{ .Values.msgbroker.port }}'
         # Database settings
         - name: RP_DB_HOST
-          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) }}
         - name: RP_DB_PORT
           value: "{{ .Values.database.port }}"
         - name: RP_DB_NAME

--- a/reportportal/templates/service-migrations/migrations-job.yaml
+++ b/reportportal/templates/service-migrations/migrations-job.yaml
@@ -30,7 +30,7 @@ spec:
         - name: POSTGRES_SSLMODE
           value: "{{ .Values.database.ssl }}"
         - name: POSTGRES_SERVER
-          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+          value: {{ .Values.database.endpoint | default (printf "%s-postgresql.%s.svc.%s" .Release.Name .Release.Namespace .Values.global.clusterDomain) }}
         - name: POSTGRES_DB
           value: "{{ .Values.database.dbName }}"
         - name: POSTGRES_PORT

--- a/reportportal/values.yaml
+++ b/reportportal/values.yaml
@@ -4,6 +4,9 @@
 ## @section Global configuration
 ##
 global:
+  ## @param global.clusterDomain Kubernetes cluster domain used to build service FQDNs
+  ##
+  clusterDomain: cluster.local
   ## @param global.imageRegistry Global image registry
   ##
   imageRegistry: ""
@@ -59,7 +62,6 @@ global:
     ## @param global.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `global.pdb.minAvailable` and `global.pdb.maxUnavailable` are empty.
     ##
     maxUnavailable: "1"
-
 
 ## @param serviceindex Core ReportPortal service for the indexing
 ##
@@ -795,7 +797,7 @@ migrations:
 database:
   secretName: ""
   passwordKeyName: "postgresql-password"
-  ## @param database.endpoint by default "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local"
+  ## @param database.endpoint by default "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}"
   ##
   endpoint:
   port: &dbport 5432
@@ -821,7 +823,7 @@ msgbroker:
   ## Incoming parameters: true (HTTPS and AMQPS), false (HTTP and AMQP)
   ##
   ssl: false
-  ## @param msgbroker.endpoint by default "{{ .Release.Name }}-rabbitmq.{{ .Release.Namespace }}.svc.cluster.local"
+  ## @param msgbroker.endpoint by default "{{ .Release.Name }}-rabbitmq.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}"
   ##
   endpoint:
   port: &msgbrokerPort 5672
@@ -841,7 +843,7 @@ searchengine:
   ## @param searchengine.passwordKeyName Key name for password in the secret
   ##
   passwordKeyName: "password"
-  ## @param searchengine.endpoint URL without protocol and port. By default, opensearch-cluster-master.{{ .Release.Namespace }}.svc.cluster.local
+  ## @param searchengine.endpoint URL without protocol and port. By default, opensearch-cluster-master.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
   ##
   endpoint:
   ## @param searchengine.ssl configure SSL connection to the search engine
@@ -1023,7 +1025,6 @@ storage:
         ## @param storage.volume.volumeConfig.csi.volumeAttributes Additional CSI attributes
         ##
         volumeAttributes: {}
-
 
 ## @section Ingress configuration
 ##
@@ -1386,7 +1387,7 @@ seaweedfs:
     enabled: false
 
   ## Single-pod all-in-one: master + volume + filer in one Deployment (1 replica, 1 PVC)
-  ## Service: <release>-seaweedfs-all-in-one.<namespace>.svc.cluster.local:8333
+  ## Service: <release>-seaweedfs-all-in-one.<namespace>.svc.{{ .Values.global.clusterDomain }}:8333
   allInOne:
     enabled: true
     ## 0 = auto-detect max volumes from disk (removes the default 8-volume cap)


### PR DESCRIPTION
Fixes #533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable cluster domain parameter (default: `cluster.local`) and updated service endpoint defaults to honor it.

* **Documentation**
  * Added the new global cluster domain option to the parameters reference and updated documented default FQDNs accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->