### PR TITLE
Bind to the PV if we have created one

### DIFF
--- a/reportportal/templates/volumes/pvc.yaml
+++ b/reportportal/templates/volumes/pvc.yaml
@@ -12,4 +12,8 @@ spec:
     requests:
       storage: {{ .Values.storage.volume.capacity }}
   storageClassName: {{ .Values.storage.volume.storageClassName }}
+{{- if (ne .Values.storage.volume.volumeConfig.type "") }}
+  {{- /* We have provisioned a PV for this PVC */}}
+  volumeName: {{ .Release.Name }}-shared-volume
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Motivation
When using a BYO storage option, the chart provisions a PV and PVC for the storage. However, the PVC doesn't have to bind to the given PV. K8s can choose a different PV satisfying the criteria such as size and storage class.

## Alternatives considered
[You can bind PVCs to a PV via `volumeName` or selector](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes-1), both of which are not presently used.

Went with `volumeName` since it is more straightforward.

## Testing

### Positive test
values.yaml
```yaml
storage:
  type: filesystem
  volume:
    storageClassName: ""
    volumeConfig:
      type: csi
      csi:
        driver: blob.csi.azure.com
        volumeHandle: st-456789-report-portal
```

<details>

<summary>Result:</summary>

```yaml
# Source: reportportal/templates/volumes/pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: testing-instance-shared-volume-claim
  annotations: 
    
    {}
spec:
  accessModes: 
    - ReadWriteMany
  resources:
    requests:
      storage: 5Gi
  storageClassName: 
  volumeName: testing-instance-shared-volume

```

</details>

### Negative test
Setup: Remove storage.volumeConfig.type "csi" from values
Result: `volumeName` is no longer present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced storage volume configuration with conditional binding support. Administrators can now explicitly bind storage claims to pre-provisioned volumes when configured, or allow Kubernetes to automatically select volumes based on storage class policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->